### PR TITLE
Basic data sync implemented via Firestore

### DIFF
--- a/app/src/main/java/illyan/jay/data/disk/JayDatabase.kt
+++ b/app/src/main/java/illyan/jay/data/disk/JayDatabase.kt
@@ -39,7 +39,7 @@ import illyan.jay.data.disk.model.RoomSession
         RoomLocation::class,
         RoomSensorEvent::class
     ],
-    version = 16,
+    version = 24,
     exportSchema = false
 )
 abstract class JayDatabase : RoomDatabase() {

--- a/app/src/main/java/illyan/jay/data/disk/JayDatabase.kt
+++ b/app/src/main/java/illyan/jay/data/disk/JayDatabase.kt
@@ -39,7 +39,7 @@ import illyan.jay.data.disk.model.RoomSession
         RoomLocation::class,
         RoomSensorEvent::class
     ],
-    version = 15,
+    version = 16,
     exportSchema = false
 )
 abstract class JayDatabase : RoomDatabase() {

--- a/app/src/main/java/illyan/jay/data/disk/Mapping.kt
+++ b/app/src/main/java/illyan/jay/data/disk/Mapping.kt
@@ -34,7 +34,6 @@ import java.time.ZoneOffset
 
 // Session
 fun RoomSession.toDomainModel() = DomainSession(
-    id = id,
     uuid = uuid,
     startDateTime = Instant.ofEpochMilli(startDateTime).atZone(ZoneOffset.UTC),
     endDateTime = endDateTime?.let { Instant.ofEpochMilli(it).atZone(ZoneOffset.UTC) },
@@ -44,10 +43,13 @@ fun RoomSession.toDomainModel() = DomainSession(
     endLocationLongitude = endLocationLongitude,
     startLocationName = startLocationName,
     endLocationName = endLocationName,
+    distance = distance,
+    ownerUserUUID = ownerUserUUID,
+    clientUUID = clientUUID,
+    isSynced = isSynced,
 )
 
 fun DomainSession.toRoomModel() = RoomSession(
-    id = id,
     uuid = uuid,
     startDateTime = startDateTime.toInstant().toEpochMilli(),
     endDateTime = endDateTime?.toInstant()?.toEpochMilli(),
@@ -57,6 +59,10 @@ fun DomainSession.toRoomModel() = RoomSession(
     endLocationLongitude = endLocationLongitude,
     startLocationName = startLocationName,
     endLocationName = endLocationName,
+    distance = distance,
+    ownerUserUUID = ownerUserUUID,
+    clientUUID = clientUUID,
+    isSynced = isSynced,
 )
 
 // Location
@@ -65,7 +71,7 @@ fun RoomLocation.toDomainModel() = DomainLocation(
     latitude = latitude,
     longitude = longitude,
     speed = speed,
-    sessionId = sessionId,
+    sessionUUID = sessionUUID,
     zonedDateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC),
     accuracy = accuracy,
     bearing = bearing,
@@ -79,7 +85,7 @@ fun DomainLocation.toRoomModel() = RoomLocation(
     latitude = latitude,
     longitude = longitude,
     speed = speed,
-    sessionId = sessionId,
+    sessionUUID = sessionUUID,
     time = zonedDateTime.toInstant().toEpochMilli(),
     accuracy = accuracy,
     bearing = bearing,
@@ -89,12 +95,14 @@ fun DomainLocation.toRoomModel() = RoomLocation(
     verticalAccuracy = verticalAccuracy
 )
 
-fun Location.toDomainModel(sessionId: Long): DomainLocation {
+fun Location.toDomainModel(
+    sessionUUID: String
+): DomainLocation {
     val domainLocation = DomainLocation(
         latitude = latitude.toFloat(),
         longitude = longitude.toFloat(),
-        sessionId = sessionId.toInt(),
-        zonedDateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC)
+        zonedDateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC),
+        sessionUUID = sessionUUID
     )
 
     if (hasSpeed()) domainLocation.speed = speed
@@ -104,7 +112,7 @@ fun Location.toDomainModel(sessionId: Long): DomainLocation {
 
     if (VERSION.SDK_INT >= VERSION_CODES.O) {
         if (hasBearingAccuracy()) domainLocation.bearingAccuracy = bearingAccuracyDegrees.toInt().toShort()
-        if (hasSpeedAccuracy()) domainLocation.speedAccuracy = speedAccuracyMetersPerSecond.toInt().toByte()
+        if (hasSpeedAccuracy()) domainLocation.speedAccuracy = speedAccuracyMetersPerSecond
         if (hasVerticalAccuracy()) domainLocation.verticalAccuracy = verticalAccuracyMeters.toInt().toShort()
     }
     return domainLocation
@@ -114,7 +122,7 @@ fun Location.toDomainModel(sessionId: Long): DomainLocation {
 fun RoomSensorEvent.toDomainModel() = DomainSensorEvent(
     id = id,
     zonedDateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC),
-    sessionId = sessionId,
+    sessionUUID = sessionUUID,
     accuracy = accuracy,
     x = x,
     y = y,
@@ -124,7 +132,7 @@ fun RoomSensorEvent.toDomainModel() = DomainSensorEvent(
 
 fun DomainSensorEvent.toRoomModel() = RoomSensorEvent(
     time = zonedDateTime.toInstant().toEpochMilli(),
-    sessionId = sessionId,
+    sessionUUID = sessionUUID,
     accuracy = accuracy,
     x = x,
     y = y,
@@ -133,8 +141,8 @@ fun DomainSensorEvent.toRoomModel() = RoomSensorEvent(
 )
 
 // Sensors
-fun SensorEvent.toDomainModel(sessionId: Long) = DomainSensorEvent(
-    sessionId = sessionId.toInt(),
+fun SensorEvent.toDomainModel(sessionUUID: String) = DomainSensorEvent(
+    sessionUUID = sessionUUID,
     zonedDateTime = Instant.ofEpochMilli(sensorTimestampToAbsoluteTime(timestamp)).atZone(ZoneOffset.UTC),
     accuracy = accuracy.toByte(),
     x = values[0],

--- a/app/src/main/java/illyan/jay/data/disk/Mapping.kt
+++ b/app/src/main/java/illyan/jay/data/disk/Mapping.kt
@@ -35,6 +35,7 @@ import java.time.ZoneOffset
 // Session
 fun RoomSession.toDomainModel() = DomainSession(
     id = id,
+    uuid = uuid,
     startDateTime = Instant.ofEpochMilli(startDateTime).atZone(ZoneOffset.UTC),
     endDateTime = endDateTime?.let { Instant.ofEpochMilli(it).atZone(ZoneOffset.UTC) },
     startLocationLatitude = startLocationLatitude,
@@ -47,6 +48,7 @@ fun RoomSession.toDomainModel() = DomainSession(
 
 fun DomainSession.toRoomModel() = RoomSession(
     id = id,
+    uuid = uuid,
     startDateTime = startDateTime.toInstant().toEpochMilli(),
     endDateTime = endDateTime?.toInstant()?.toEpochMilli(),
     startLocationLatitude = startLocationLatitude,

--- a/app/src/main/java/illyan/jay/data/disk/dao/LocationDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/LocationDao.kt
@@ -23,6 +23,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import illyan.jay.data.disk.model.RoomLocation
 import kotlinx.coroutines.flow.Flow
@@ -51,23 +52,31 @@ interface LocationDao {
     fun deleteLocation(location: RoomLocation)
 
     @Delete
-    fun deleteLocationsForSession(locations: List<RoomLocation>)
+    fun deleteLocations(locations: List<RoomLocation>)
 
     @Query("DELETE FROM location")
     fun deleteLocations()
 
-    @Query("DELETE FROM location WHERE sessionId = :sessionId")
-    fun deleteLocationsForSession(sessionId: Long)
+    @Query("DELETE FROM location WHERE sessionUUID = :sessionUUID")
+    fun deleteLocations(sessionUUID: String)
 
+    @Transaction
     @Query("SELECT * FROM location WHERE id = :id")
     fun getLocation(id: Long): Flow<RoomLocation?>
 
-    @Query("SELECT * FROM location WHERE sessionId = :sessionId")
-    fun getLocations(sessionId: Long): Flow<List<RoomLocation>>
+    @Transaction
+    @Query("SELECT * FROM location WHERE sessionUUID = :sessionUUID")
+    fun getLocations(sessionUUID: String): Flow<List<RoomLocation>>
 
+    @Transaction
+    @Query("SELECT * FROM location WHERE sessionUUID IN(:sessionUUIDs)")
+    fun getLocations(sessionUUIDs: List<String>): Flow<List<RoomLocation>>
+
+    @Transaction
     @Query("SELECT * FROM location ORDER BY id DESC LIMIT :limit")
     fun getLatestLocations(limit: Long): Flow<List<RoomLocation>>
 
-    @Query("SELECT * FROM location WHERE sessionId = :sessionId ORDER BY id DESC LIMIT :limit")
-    fun getLatestLocations(sessionId: Long, limit: Long): Flow<List<RoomLocation>>
+    @Transaction
+    @Query("SELECT * FROM location WHERE sessionUUID = :sessionUUID ORDER BY id DESC LIMIT :limit")
+    fun getLatestLocations(sessionUUID: String, limit: Long): Flow<List<RoomLocation>>
 }

--- a/app/src/main/java/illyan/jay/data/disk/dao/SensorEventDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/SensorEventDao.kt
@@ -56,12 +56,12 @@ interface SensorEventDao {
     @Query("DELETE FROM sensor_events")
     fun deleteSensorEvents()
 
-    @Query("DELETE FROM sensor_events WHERE sessionId = :sessionId")
-    fun deleteSensorEventsForSession(sessionId: Long)
+    @Query("DELETE FROM sensor_events WHERE sessionUUID = :sessionUUID")
+    fun deleteSensorEventsForSession(sessionUUID: String)
 
     @Query("SELECT * FROM sensor_events WHERE id = :id")
     fun getSensorEvent(id: Long): Flow<RoomSensorEvent?>
 
-    @Query("SELECT * FROM sensor_events WHERE sessionId = :sessionId")
-    fun getSensorEvents(sessionId: Long): Flow<List<RoomSensorEvent>>
+    @Query("SELECT * FROM sensor_events WHERE sessionUUID = :sessionUUID")
+    fun getSensorEvents(sessionUUID: String): Flow<List<RoomSensorEvent>>
 }

--- a/app/src/main/java/illyan/jay/data/disk/dao/SessionDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/SessionDao.kt
@@ -23,6 +23,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import illyan.jay.data.disk.model.RoomSession
 import kotlinx.coroutines.flow.Flow
@@ -30,7 +31,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface SessionDao {
     @Insert
-    fun insertSession(session: RoomSession): Long
+    fun insertSession(session: RoomSession)
 
     @Insert
     fun insertSessions(sessions: List<RoomSession>)
@@ -53,36 +54,95 @@ interface SessionDao {
     @Delete
     fun deleteSessions(sessions: List<RoomSession>)
 
-    @Query("DELETE FROM session")
-    fun deleteSessions()
+    @Transaction
+    @Query("DELETE FROM session WHERE ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL")
+    fun deleteSessions(ownerUserUUID: String? = null)
 
-    @Query("SELECT * FROM session")
-    fun getSessions(): Flow<List<RoomSession>>
+    @Transaction
+    @Query("DELETE FROM session WHERE ownerUserUUID IS NULL")
+    fun deleteNotOwnedSessions()
 
-    @Query("SELECT id FROM session")
-    fun getSessionIds(): Flow<List<Long>>
+    @Transaction
+    @Query("DELETE FROM session WHERE ownerUserUUID IS :ownerUserUUID")
+    fun deleteSessionsByOwner(ownerUserUUID: String? = null)
 
-    @Query("SELECT * FROM session WHERE id = :id LIMIT 1")
-    fun getSession(id: Long): Flow<RoomSession?>
+    @Transaction
+    @Query("DELETE FROM session WHERE ownerUserUUID IS :ownerUserUUID AND endDateTime IS NOT NULL")
+    fun deleteStoppedSessionsByOwner(ownerUserUUID: String? = null)
 
-    @Query("SELECT * FROM session WHERE endDateTime is NULL")
-    fun getOngoingSessions(): Flow<List<RoomSession>>
+    @Transaction
+    @Query("SELECT * FROM session WHERE ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL")
+    fun getSessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
 
-    @Query("SELECT id FROM session WHERE endDateTime is NULL")
-    fun getOngoingSessionIds(): Flow<List<Long>>
+    @Transaction
+    @Query("SELECT uuid FROM session WHERE ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL")
+    fun getSessionUUIDs(ownerUserUUID: String? = null): Flow<List<String>>
 
-    @Query("SELECT id FROM session WHERE uuid is NULL")
-    fun getLocalOnlySessionIds(): Flow<List<Long>>
+    @Transaction
+    @Query("SELECT * FROM session WHERE uuid = :uuid AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL) LIMIT 1")
+    fun getSession(uuid: String, ownerUserUUID: String? = null): Flow<RoomSession?>
 
-    @Query("SELECT id FROM session WHERE uuid is NOT NULL")
-    fun getSyncedSessionIds(): Flow<List<Long>>
+    @Transaction
+    @Query("SELECT * FROM session WHERE endDateTime IS NOT NULL AND ownerUserUUID IS :ownerUserUUID")
+    fun getStoppedSessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
 
-    @Query("SELECT * FROM session WHERE uuid is NULL")
-    fun getLocalOnlySessions(): Flow<List<RoomSession>>
+    @Transaction
+    @Query("SELECT * FROM session WHERE endDateTime IS NULL AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL)")
+    fun getOngoingSessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
 
-    @Query("SELECT * FROM session WHERE uuid is NOT NULL")
-    fun getSyncedSessions(): Flow<List<RoomSession>>
+    @Transaction
+    @Query("SELECT uuid FROM session WHERE endDateTime IS NULL AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL)")
+    fun getOngoingSessionUUIDs(ownerUserUUID: String? = null): Flow<List<String>>
 
-    @Query("UPDATE session SET uuid = NULL")
-    fun removeUUIDsFromSessions()
+    @Transaction
+    @Query("SELECT uuid FROM session WHERE NOT isSynced AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL)")
+    fun getLocalOnlySessionUUIDs(ownerUserUUID: String? = null): Flow<List<String>>
+
+    @Transaction
+    @Query("SELECT uuid FROM session WHERE isSynced AND ownerUserUUID IS :ownerUserUUID")
+    fun getSyncedSessionUUIDs(ownerUserUUID: String? = null): Flow<List<String>>
+
+    @Transaction
+    @Query("SELECT * FROM session WHERE NOT isSynced AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL)")
+    fun getLocalOnlySessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
+
+    @Transaction
+    @Query("SELECT * FROM session WHERE isSynced AND ownerUserUUID IS :ownerUserUUID")
+    fun getSyncedSessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
+
+    @Transaction
+    @Query("SELECT * FROM session WHERE ownerUserUUID IS NULL")
+    fun getAllNotOwnedSessions(): Flow<List<RoomSession>>
+
+    @Transaction
+    @Query("SELECT * FROM session WHERE ownerUserUUID IS :ownerUserUUID")
+    fun getSessionsByOwner(ownerUserUUID: String? = null): Flow<List<RoomSession>>
+
+    @Transaction
+    @Query("UPDATE session SET uuid = :newUUID WHERE uuid IS :currentUUID AND ownerUserUUID IS :ownerUserUUID")
+    fun refreshSessionUUID(currentUUID: String, newUUID: String, ownerUserUUID: String): Int
+
+    @Transaction
+    @Query("UPDATE session SET ownerUserUUID = :ownerUserUUID WHERE ownerUserUUID IS NULL")
+    fun ownAllNotOwnedSessions(ownerUserUUID: String): Int
+
+    @Transaction
+    @Query("UPDATE session SET ownerUserUUID = :ownerUserUUID WHERE ownerUserUUID IS NULL AND uuid = :uuid")
+    fun ownNotOwnedSession(uuid: String, ownerUserUUID: String): Int
+
+    @Transaction
+    @Query("UPDATE session SET isSynced = :isSynced WHERE uuid IN(:uuids)")
+    fun updateSyncOnSessions(uuids: List<String>, isSynced: Boolean)
+
+    @Transaction
+    @Query("UPDATE session SET ownerUserUUID = :ownerUserUUID WHERE uuid IN(:uuids)")
+    fun ownSessions(uuids: List<String>, ownerUserUUID: String)
+
+    @Transaction
+    @Query("UPDATE session SET ownerUserUUID = NULL WHERE uuid IN(:uuids)")
+    fun disownSessions(uuids: List<String>)
+
+    @Transaction
+    @Query("UPDATE session SET ownerUserUUID = NULL WHERE ownerUserUUID IS :ownerUserUUID")
+    fun disownSessions(ownerUserUUID: String)
 }

--- a/app/src/main/java/illyan/jay/data/disk/dao/SessionDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/SessionDao.kt
@@ -70,4 +70,19 @@ interface SessionDao {
 
     @Query("SELECT id FROM session WHERE endDateTime is NULL")
     fun getOngoingSessionIds(): Flow<List<Long>>
+
+    @Query("SELECT id FROM session WHERE uuid is NULL")
+    fun getLocalOnlySessionIds(): Flow<List<Long>>
+
+    @Query("SELECT id FROM session WHERE uuid is NOT NULL")
+    fun getSyncedSessionIds(): Flow<List<Long>>
+
+    @Query("SELECT * FROM session WHERE uuid is NULL")
+    fun getLocalOnlySessions(): Flow<List<RoomSession>>
+
+    @Query("SELECT * FROM session WHERE uuid is NOT NULL")
+    fun getSyncedSessions(): Flow<List<RoomSession>>
+
+    @Query("UPDATE session SET uuid = NULL")
+    fun removeUUIDsFromSessions()
 }

--- a/app/src/main/java/illyan/jay/data/disk/datasource/LocationDiskDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/disk/datasource/LocationDiskDataSource.kt
@@ -40,7 +40,7 @@ class LocationDiskDataSource @Inject constructor(
     /**
      * Get latest (most up to date) locations as a Flow for a particular session.
      *
-     * @param sessionId particular session's ID, which is the
+     * @param sessionUUID particular session's ID, which is the
      * foreign key of the location data returned.
      * @param limit number of latest location data returned in order from
      * the freshest location to older location data.
@@ -48,8 +48,8 @@ class LocationDiskDataSource @Inject constructor(
      * @return location data flow for a particular session in order from
      * the freshest location to older location data.
      */
-    fun getLatestLocations(sessionId: Long, limit: Long) =
-        locationDao.getLatestLocations(sessionId, limit)
+    fun getLatestLocations(sessionUUID: String, limit: Long) =
+        locationDao.getLatestLocations(sessionUUID, limit)
             .map { it.map(RoomLocation::toDomainModel) }
 
     fun getLatestLocations(limit: Long) =
@@ -59,12 +59,15 @@ class LocationDiskDataSource @Inject constructor(
     /**
      * Get locations' data as a Flow for a particular session.
      *
-     * @param sessionId particular session's ID, which is the
+     * @param sessionUUID particular session's ID, which is the
      * foreign key of location data returned.
      *
      * @return location data flow for a particular session.
      */
-    fun getLocations(sessionId: Long) = locationDao.getLocations(sessionId)
+    fun getLocations(sessionUUID: String) = locationDao.getLocations(sessionUUID)
+        .map { it.map(RoomLocation::toDomainModel) }
+
+    fun getLocations(sessionUUIDs: List<String>) = locationDao.getLocations(sessionUUIDs)
         .map { it.map(RoomLocation::toDomainModel) }
 
     /**
@@ -86,5 +89,5 @@ class LocationDiskDataSource @Inject constructor(
     fun saveLocations(locations: List<DomainLocation>) =
         locationDao.upsertLocations(locations.map(DomainLocation::toRoomModel))
 
-    fun deleteLocationForSession(sessionId: Long) = locationDao.deleteLocationsForSession(sessionId)
+    fun deleteLocationForSession(sessionUUID: String) = locationDao.deleteLocations(sessionUUID)
 }

--- a/app/src/main/java/illyan/jay/data/disk/datasource/SensorEventDiskDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/disk/datasource/SensorEventDiskDataSource.kt
@@ -46,18 +46,18 @@ class SensorEventDiskDataSource @Inject constructor(
      *
      * @return sensorEvent data for a particular session.
      */
-    fun getSensorEvents(session: DomainSession) = getSensorEvents(session.id)
+    fun getSensorEvents(session: DomainSession) = getSensorEvents(session.uuid)
 
     /**
      * Get sensorEvents' data as a Flow for a particular session.
      *
-     * @param sessionId particular session's ID, which is the
+     * @param sessionUUID particular session's ID, which is the
      * foreign key of sensorEvent data returned.
      *
      * @return sensorEvent data flow for a particular session.
      */
-    fun getSensorEvents(sessionId: Long) =
-        sensorEventDao.getSensorEvents(sessionId)
+    fun getSensorEvents(sessionUUID: String) =
+        sensorEventDao.getSensorEvents(sessionUUID)
             .map { it.map(RoomSensorEvent::toDomainModel) }
 
     /**
@@ -80,6 +80,6 @@ class SensorEventDiskDataSource @Inject constructor(
     fun saveSensorEvents(sensorEvents: List<DomainSensorEvent>) =
         sensorEventDao.upsertSensorEvents(sensorEvents.map(DomainSensorEvent::toRoomModel))
 
-    fun deleteSensorEventsForSession(sessionId: Long) =
-        sensorEventDao.deleteSensorEventsForSession(sessionId)
+    fun deleteSensorEventsForSession(sessionUUID: String) =
+        sensorEventDao.deleteSensorEventsForSession(sessionUUID)
 }

--- a/app/src/main/java/illyan/jay/data/disk/datasource/SessionDiskDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/disk/datasource/SessionDiskDataSource.kt
@@ -47,7 +47,17 @@ class SessionDiskDataSource @Inject constructor(
      */
     fun getSessions() = sessionDao.getSessions().map { it.map(RoomSession::toDomainModel) }
 
+    fun getLocalOnlySessions() = sessionDao.getLocalOnlySessions()
+        .map { it.map(RoomSession::toDomainModel) }
+
+    fun getSyncedSessions() = sessionDao.getSyncedSessions()
+        .map { it.map(RoomSession::toDomainModel) }
+
     fun getSessionIds() = sessionDao.getSessionIds()
+
+    fun getLocalOnlySessionIds() = sessionDao.getLocalOnlySessionIds()
+
+    fun getSyncedSessionIds() = sessionDao.getSyncedSessionIds()
 
     /**
      * Get a particular session by its ID.
@@ -141,4 +151,6 @@ class SessionDiskDataSource @Inject constructor(
 
     fun deleteSessions(sessions: List<DomainSession>) =
         sessionDao.deleteSessions(sessions.map(DomainSession::toRoomModel))
+
+    fun removeUUIDsFromSessions() = sessionDao.removeUUIDsFromSessions()
 }

--- a/app/src/main/java/illyan/jay/data/disk/model/RoomLocation.kt
+++ b/app/src/main/java/illyan/jay/data/disk/model/RoomLocation.kt
@@ -28,22 +28,22 @@ import androidx.room.PrimaryKey
     foreignKeys = [
         ForeignKey(
             entity = RoomSession::class,
-            parentColumns = ["id"],
-            childColumns = ["sessionId"]
+            parentColumns = ["uuid"],
+            childColumns = ["sessionUUID"]
         )
     ],
-    indices = [Index(value = ["sessionId"])]
+    indices = [Index(value = ["sessionUUID"])]
 )
 data class RoomLocation(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,
-    val sessionId: Int,
+    val sessionUUID: String,
     val latitude: Float,
     val longitude: Float,
     val accuracy: Byte,
     val time: Long, // in millis
     val speed: Float,
-    val speedAccuracy: Byte, // in meters per second
+    val speedAccuracy: Float, // in meters per second
     val bearing: Short,
     val bearingAccuracy: Short, // in degrees
     val altitude: Short,

--- a/app/src/main/java/illyan/jay/data/disk/model/RoomSensorEvent.kt
+++ b/app/src/main/java/illyan/jay/data/disk/model/RoomSensorEvent.kt
@@ -28,16 +28,16 @@ import androidx.room.PrimaryKey
     foreignKeys = [
         ForeignKey(
             entity = RoomSession::class,
-            parentColumns = ["id"],
-            childColumns = ["sessionId"]
+            parentColumns = ["uuid"],
+            childColumns = ["sessionUUID"]
         )
     ],
-    indices = [Index(value = ["sessionId"]), Index(value = ["time"])]
+    indices = [Index(value = ["sessionUUID"]), Index(value = ["time"])]
 )
 data class RoomSensorEvent(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,
-    val sessionId: Int,
+    val sessionUUID: String,
     val time: Long, // in millis
     val accuracy: Byte, // SensorManager.SENSOR_STATUS_ACCURACY_HIGH
     val x: Float,

--- a/app/src/main/java/illyan/jay/data/disk/model/RoomSession.kt
+++ b/app/src/main/java/illyan/jay/data/disk/model/RoomSession.kt
@@ -21,15 +21,15 @@ package illyan.jay.data.disk.model
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(
     tableName = "session",
-    indices = [Index(value = ["id"])]
+    indices = [Index(value = ["uuid"])]
 )
 data class RoomSession(
-    @PrimaryKey(autoGenerate = true)
-    val id: Long = 0,
-    val uuid: String? = null,
+    @PrimaryKey
+    val uuid: String = UUID.randomUUID().toString(),
     val startDateTime: Long,
     var endDateTime: Long? = null,
     var startLocationLatitude: Float? = null,
@@ -37,5 +37,9 @@ data class RoomSession(
     var endLocationLatitude: Float? = null,
     var endLocationLongitude: Float? = null,
     var startLocationName: String? = null,
-    var endLocationName: String? = null
+    var endLocationName: String? = null,
+    val distance: Float? = null,
+    val ownerUserUUID: String? = null,
+    val clientUUID: String? = null,
+    val isSynced: Boolean = false
 )

--- a/app/src/main/java/illyan/jay/data/network/Mapping.kt
+++ b/app/src/main/java/illyan/jay/data/network/Mapping.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ *
+ * Jay is a driver behaviour analytics app.
+ *
+ * This file is part of Jay.
+ *
+ * Jay is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ * Jay is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Jay.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package illyan.jay.data.network
+
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.GeoPoint
+import illyan.jay.data.network.model.PathDocument
+import illyan.jay.domain.model.DomainLocation
+import illyan.jay.domain.model.DomainSession
+import illyan.jay.util.toGeoPoint
+import illyan.jay.util.toTimestamp
+import illyan.jay.util.toZonedDateTime
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.util.UUID
+
+fun DomainSession.toHashMap() = hashMapOf(
+    "id" to uuid,
+    "distance" to distance,
+    "endDateTime" to endDateTime?.toTimestamp(),
+    "endLocation" to endLocation?.toGeoPoint(),
+    "endLocationName" to endLocationName,
+    "startDateTime" to startDateTime.toTimestamp(),
+    "startLocation" to startLocation?.toGeoPoint(),
+    "startLocationName" to startLocationName
+)
+
+// TODO: Limit size to 1MiB per hashMap
+fun List<DomainLocation>.toPaths(
+    sessionId: String
+): List<PathDocument> {
+
+    val accuracyChangeTimestamps = mutableListOf<Timestamp>()
+    val accuracyChanges = mutableListOf<Byte>()
+    val altitudes = mutableListOf<Short>()
+    val bearingAccuracyChangeTimestamps = mutableListOf<Timestamp>()
+    val bearingAccuracyChanges = mutableListOf<Short>()
+    val bearings = mutableListOf<Short>()
+    val coords = mutableListOf<GeoPoint>()
+    val speeds = mutableListOf<Float>()
+    val timestamps = mutableListOf<Timestamp>()
+    val verticalAccuracyChangeTimestamps = mutableListOf<Timestamp>()
+    val verticalAccuracyChanges = mutableListOf<Short>()
+
+    val sortedLocations = sortedBy { it.zonedDateTime.toInstant().toEpochMilli() }
+
+    sortedLocations.forEach {
+        val timestamp = it.zonedDateTime.toTimestamp()
+
+        altitudes.add(it.altitude)
+        bearings.add(it.bearing)
+        coords.add(it.latLng.toGeoPoint())
+        speeds.add(it.speed)
+        timestamps.add(timestamp)
+
+        val lastAccuracyChange = accuracyChanges.lastOrNull()
+        if (lastAccuracyChange != it.accuracy) {
+            accuracyChangeTimestamps.add(timestamp)
+            accuracyChanges.add(it.accuracy)
+        }
+
+        val lastBearingAccuracyChange = bearingAccuracyChanges.lastOrNull()
+        if (lastBearingAccuracyChange != it.bearingAccuracy) {
+            bearingAccuracyChangeTimestamps.add(timestamp)
+            bearingAccuracyChanges.add(it.bearingAccuracy)
+        }
+
+        val lastVerticalAccuracyChange = verticalAccuracyChanges.lastOrNull()
+        if (lastVerticalAccuracyChange != it.verticalAccuracy) {
+            verticalAccuracyChangeTimestamps.add(timestamp)
+            verticalAccuracyChanges.add(it.verticalAccuracy)
+        }
+    }
+
+    return listOf(
+        PathDocument(
+            uuid = UUID.randomUUID().toString(),
+            accuracyChangeTimestamps = accuracyChangeTimestamps.toList(),
+            accuracyChanges = accuracyChanges.toList(),
+            altitudes = altitudes.toList(),
+            bearingAccuracyChangeTimestamps = bearingAccuracyChangeTimestamps.toList(),
+            bearingAccuracyChanges = bearingAccuracyChanges.toList(),
+            bearings = bearings.toList(),
+            coords = coords.toList(),
+            sessionId = sessionId,
+            speeds = speeds.toList(),
+            timestamps = timestamps.toList(),
+            verticalAccuracyChangeTimestamps = verticalAccuracyChangeTimestamps.toList(),
+            verticalAccuracyChanges = verticalAccuracyChanges.toList(),
+        )
+    )
+}
+
+fun PathDocument.toHashMap() = hashMapOf(
+    "uuid" to uuid,
+    "accuracyChangeTimestamps" to accuracyChangeTimestamps,
+    "accuracyChanges" to accuracyChanges.map { it.toInt() },
+    "altitudes" to altitudes.map { it.toInt() },
+    "bearingAccuracyChangeTimestamps" to bearingAccuracyChangeTimestamps,
+    "bearingAccuracyChanges" to bearingAccuracyChanges.map { it.toInt() },
+    "bearings" to bearings.map { it.toInt() },
+    "coords" to coords,
+    "sessionId" to sessionId,
+    "speeds" to speeds,
+    "timestamps" to timestamps,
+    "verticalAccuracyChangeTimestamps" to verticalAccuracyChangeTimestamps,
+    "verticalAccuracyChanges" to verticalAccuracyChanges.map { it.toInt() }
+)
+
+fun Map<String, Any?>.toDomainSession(id: String?): DomainSession {
+    val startLocation = this["startLocation"] as GeoPoint?
+    val endLocation = this["endLocation"] as GeoPoint?
+    return DomainSession(
+        uuid = id,
+        startDateTime = (this["startDateTime"] as Timestamp?)?.toZonedDateTime() ?: ZonedDateTime
+            .ofInstant(Instant.EPOCH, ZoneOffset.UTC),
+        endDateTime = (this["endDateTime"] as Timestamp?)?.toZonedDateTime(),
+        startLocationLatitude = startLocation?.latitude?.toFloat(),
+        startLocationLongitude = startLocation?.longitude?.toFloat(),
+        endLocationLatitude = endLocation?.latitude?.toFloat(),
+        endLocationLongitude = endLocation?.longitude?.toFloat(),
+        startLocationName = this["startLocationName"] as String?,
+        endLocationName = this["endLocationName"] as String?,
+        distance = (this["distance"] as Double?)?.toFloat()
+    )
+}
+
+fun List<DocumentSnapshot>.toDomainLocations(): List<DomainLocation> {
+    val domainLocations = mutableListOf<DomainLocation>()
+
+    forEach { document ->
+        val accuracyChangeTimestamps = document.get("accuracyChangeTimestamps") as List<Timestamp>
+        val accuracyChanges = document.get("accuracyChanges") as List<Int>
+        val altitudes = document.get("altitudes") as List<Int>
+        val bearingAccuracyChangeTimestamps = document.get("bearingAccuracyChangeTimestamps") as List<Timestamp>
+        val bearingAccuracyChanges = document.get("bearingAccuracyChanges") as List<Int>
+        val bearings = document.get("bearings") as List<Int>
+        val coords = document.get("coords") as List<GeoPoint>
+        val speeds = document.get("speeds") as List<Float>
+        val speedAccuracyChangeTimestamps = document.get("speedAccuracyChangeTimestamps") as List<Timestamp>
+        val speedAccuracyChanges = document.get("speedAccuracyChanges") as List<Float>
+        val timestamps = document.get("timestamps") as List<Timestamp>
+        val verticalAccuracyChangeTimestamps = document.get("verticalAccuracyChangeTimestamps") as List<Timestamp>
+        val verticalAccuracyChanges = document.get("verticalAccuracyChanges") as List<Int>
+
+        timestamps.forEachIndexed { index, timestamp ->
+            val indexOfLastAccuracyChange = accuracyChangeTimestamps.indexOfLast {
+                it.toZonedDateTime().isBefore(timestamp.toZonedDateTime())
+            }
+            val indexOfLastBearingAccuracyChange = bearingAccuracyChangeTimestamps.indexOfLast {
+                it.toZonedDateTime().isBefore(timestamp.toZonedDateTime())
+            }
+            val indexOfLastVerticalAccuracyChange = verticalAccuracyChangeTimestamps.indexOfLast {
+                it.toZonedDateTime().isBefore(timestamp.toZonedDateTime())
+            }
+            val indexOfLastSpeedAccuracyChange = speedAccuracyChangeTimestamps.indexOfLast {
+                it.toZonedDateTime().isBefore(timestamp.toZonedDateTime())
+            }
+
+            domainLocations.add(
+                DomainLocation( // FIXME: save speed accuracy next time?
+                    sessionId = -1,
+                    zonedDateTime = timestamp.toZonedDateTime(),
+                    latitude = coords[index].latitude.toFloat(),
+                    longitude = coords[index].longitude.toFloat(),
+                    speed = speeds[index],
+                    speedAccuracy = speedAccuracyChanges[indexOfLastSpeedAccuracyChange].toInt().toByte(),
+                    accuracy = accuracyChanges[indexOfLastAccuracyChange].toByte(),
+                    bearing = bearings[index].toShort(),
+                    bearingAccuracy = bearingAccuracyChanges[indexOfLastBearingAccuracyChange].toShort(),
+                    altitude = altitudes[index].toShort(),
+                    verticalAccuracy = verticalAccuracyChanges[indexOfLastVerticalAccuracyChange].toShort()
+                )
+            )
+        }
+    }
+
+    return domainLocations.sortedBy { it.zonedDateTime.toInstant().toEpochMilli() }
+}

--- a/app/src/main/java/illyan/jay/data/network/datasource/FirestoreModule.kt
+++ b/app/src/main/java/illyan/jay/data/network/datasource/FirestoreModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -16,26 +16,21 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package illyan.jay.data.disk.model
+package illyan.jay.data.network.datasource
 
-import androidx.room.Entity
-import androidx.room.Index
-import androidx.room.PrimaryKey
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
-@Entity(
-    tableName = "session",
-    indices = [Index(value = ["id"])]
-)
-data class RoomSession(
-    @PrimaryKey(autoGenerate = true)
-    val id: Long = 0,
-    val uuid: String? = null,
-    val startDateTime: Long,
-    var endDateTime: Long? = null,
-    var startLocationLatitude: Float? = null,
-    var startLocationLongitude: Float? = null,
-    var endLocationLatitude: Float? = null,
-    var endLocationLongitude: Float? = null,
-    var startLocationName: String? = null,
-    var endLocationName: String? = null
-)
+@Module
+@InstallIn(SingletonComponent::class)
+object FirestoreModule {
+
+    @Singleton
+    @Provides
+    fun provideFirestore() = Firebase.firestore
+}

--- a/app/src/main/java/illyan/jay/data/network/datasource/LocationNetworkDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/network/datasource/LocationNetworkDataSource.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ *
+ * Jay is a driver behaviour analytics app.
+ *
+ * This file is part of Jay.
+ *
+ * Jay is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ * Jay is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Jay.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package illyan.jay.data.network.datasource
+
+import com.google.firebase.firestore.FirebaseFirestore
+import illyan.jay.data.network.toDomainLocations
+import illyan.jay.domain.interactor.AuthInteractor
+import illyan.jay.domain.model.DomainLocation
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LocationNetworkDataSource @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    private val authInteractor: AuthInteractor
+) {
+    fun getLocations(
+        sessionId: String,
+        listener: (List<DomainLocation>) -> Unit
+    ) = getLocations(listOf(sessionId), listener)
+
+    fun getLocations(
+        sessionUUIDs: List<String>,
+        listener: (List<DomainLocation>) -> Unit
+    ) {
+        if (authInteractor.isUserSignedIn) {
+            firestore
+                .collection(SessionNetworkDataSource.PathsCollectionPath)
+                .whereIn(
+                    "sessionUUID",
+                    sessionUUIDs
+                )
+                .get()
+                .addOnSuccessListener { snapshot ->
+                    listener(snapshot.documents.toDomainLocations())
+                }
+                .addOnCanceledListener { listener(emptyList()) }
+                .addOnFailureListener { listener(emptyList()) }
+        } else {
+            listener(emptyList())
+        }
+    }
+}

--- a/app/src/main/java/illyan/jay/data/network/datasource/SessionNetworkDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/network/datasource/SessionNetworkDataSource.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ *
+ * Jay is a driver behaviour analytics app.
+ *
+ * This file is part of Jay.
+ *
+ * Jay is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ * Jay is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Jay.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package illyan.jay.data.network.datasource
+
+import android.app.Activity
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import com.google.maps.android.ktx.utils.sphericalPathLength
+import illyan.jay.data.disk.datasource.SessionDiskDataSource
+import illyan.jay.data.network.toDomainLocations
+import illyan.jay.data.network.toDomainSession
+import illyan.jay.data.network.toHashMap
+import illyan.jay.data.network.toPaths
+import illyan.jay.domain.interactor.AuthInteractor
+import illyan.jay.domain.model.DomainLocation
+import illyan.jay.domain.model.DomainSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SessionNetworkDataSource @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    private val authInteractor: AuthInteractor,
+    private val sessionDiskDataSource: SessionDiskDataSource,
+) {
+    fun getLocations(
+        sessionId: String,
+        coroutineScope: CoroutineScope,
+    ) = flow<List<DomainLocation>> {
+        if (authInteractor.isUserSignedIn) {
+            firestore
+                .collection(PathsCollectionPath)
+                .whereEqualTo(
+                    "owner",
+                    "$UsersCollectionPath/${authInteractor.userUUID}"
+                )
+                .whereEqualTo(
+                    "partOfSession",
+                    "$SessionsCollectionPath/$sessionId"
+                )
+                .get()
+                .addOnSuccessListener { snapshot ->
+                    coroutineScope.launch { emit(snapshot.documents.toDomainLocations()) }
+                }
+                .addOnCanceledListener { coroutineScope.launch { emit(emptyList()) } }
+                .addOnFailureListener { coroutineScope.launch { emit(emptyList()) } }
+        } else {
+            emit(emptyList())
+        }
+    }
+
+    fun getSessions(
+        activity: Activity,
+        listener: (List<DomainSession>) -> Unit
+    ) {
+        if (authInteractor.isUserSignedIn) {
+            Timber.d("Connecting snapshot listener to Firebase")
+            firestore
+                .collection(UsersCollectionPath)
+                .document(authInteractor.userUUID.toString())
+                .addSnapshotListener(activity) { snapshot, error ->
+                    val domainSessions = (snapshot?.get("sessions") as List<Map<String, Any>>?)?.map {
+                        it.toDomainSession(it["id"] as String?)
+                    } ?: emptyList()
+                    Timber.d("Firebase got sessions with IDs: ${
+                        domainSessions.map { it.uuid.toString().substring(0..3) }
+                    }")
+                    listener(domainSessions)
+                }
+        } else {
+            Timber.d("Connecting snapshot listener to Firebase")
+            listener(emptyList())
+        }
+    }
+
+    fun insertSession(
+        domainSession: DomainSession,
+        domainLocations: List<DomainLocation>,
+        coroutineScope: CoroutineScope,
+    ) {
+        // TODO: upload path data first
+        // TODO: upload session data
+        // TODO: update/upload user data with it
+        // TODO: don't assume to update session data
+
+        if (domainSession.uuid == null && authInteractor.isUserSignedIn) {
+            domainSession.uuid = UUID.randomUUID().toString()
+            if (domainSession.distance == null) {
+                domainSession.distance = domainLocations
+                    .sortedBy { it.zonedDateTime.toInstant().toEpochMilli() }
+                    .map { it.latLng }.sphericalPathLength().toFloat()
+            }
+            val paths = domainLocations.toPaths(domainSession.uuid.toString())
+
+            val pathRefs = paths.map {
+                firestore
+                    .collection(PathsCollectionPath)
+                    .document(it.uuid) to it
+            }
+
+            val userRef = firestore
+                .collection(UsersCollectionPath)
+                .document(authInteractor.userUUID!!)
+
+            firestore.runBatch { batch ->
+                pathRefs.forEach { batch.set(it.first, it.second.toHashMap()) }
+
+                batch.set(
+                    userRef,
+                    mapOf("sessions" to FieldValue.arrayUnion(domainSession.toHashMap())),
+                    SetOptions.merge()
+                )
+            }.addOnSuccessListener {
+                coroutineScope.launch(Dispatchers.IO) {
+                    sessionDiskDataSource.saveSession(domainSession)
+                }
+            }
+        } // else it is already synced to the cloud
+
+    }
+
+    fun deleteUserData(coroutineScope: CoroutineScope) {
+        if (authInteractor.isUserSignedIn) {
+            firestore
+                .collection(UsersCollectionPath)
+                .document(authInteractor.userUUID!!)
+                .get()
+                .addOnSuccessListener { userSnapshot ->
+                    val domainSessionIds = (userSnapshot["sessions"] as List<Map<String, Any>>?)
+                        ?.map { it["id"] as String? } ?: emptyList()
+                    if (domainSessionIds.firstOrNull() != null) { // at least one not null element
+                        firestore
+                            .collection(PathsCollectionPath)
+                            .whereIn("sessionId", domainSessionIds)
+                            .get()
+                            .addOnSuccessListener { pathSnapshot ->
+                                pathSnapshot.documents.forEach {
+                                    it.reference.delete()
+                                }
+                                userSnapshot.reference.delete()
+                            }
+                    }
+                }
+        }
+    }
+
+    companion object {
+        const val UsersCollectionPath = "users"
+        const val SessionsCollectionPath = "sessions"
+        const val PathsCollectionPath = "paths"
+    }
+}

--- a/app/src/main/java/illyan/jay/data/network/model/PathDocument.kt
+++ b/app/src/main/java/illyan/jay/data/network/model/PathDocument.kt
@@ -31,8 +31,10 @@ data class PathDocument(
     val bearingAccuracyChanges: List<Short>,
     val bearings: List<Short>,
     val coords: List<GeoPoint>,
-    val sessionId: String, // reference of the session this path is part of
+    val sessionUUID: String, // reference of the session this path is part of
     val speeds: List<Float>,
+    val speedAccuracyChangeTimestamps: List<Timestamp>,
+    val speedAccuracyChanges: List<Float>,
     val timestamps: List<Timestamp>,
     val verticalAccuracyChangeTimestamps: List<Timestamp>,
     val verticalAccuracyChanges: List<Short>

--- a/app/src/main/java/illyan/jay/data/network/model/PathDocument.kt
+++ b/app/src/main/java/illyan/jay/data/network/model/PathDocument.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ *
+ * Jay is a driver behaviour analytics app.
+ *
+ * This file is part of Jay.
+ *
+ * Jay is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ * Jay is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Jay.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package illyan.jay.data.network.model
+
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.GeoPoint
+import java.util.UUID
+
+data class PathDocument(
+    var uuid: String = UUID.randomUUID().toString(),
+    val accuracyChangeTimestamps: List<Timestamp>,
+    val accuracyChanges: List<Byte>,
+    val altitudes: List<Short>,
+    val bearingAccuracyChangeTimestamps: List<Timestamp>,
+    val bearingAccuracyChanges: List<Short>,
+    val bearings: List<Short>,
+    val coords: List<GeoPoint>,
+    val sessionId: String, // reference of the session this path is part of
+    val speeds: List<Float>,
+    val timestamps: List<Timestamp>,
+    val verticalAccuracyChangeTimestamps: List<Timestamp>,
+    val verticalAccuracyChanges: List<Short>
+)

--- a/app/src/main/java/illyan/jay/di/AppModule.kt
+++ b/app/src/main/java/illyan/jay/di/AppModule.kt
@@ -23,6 +23,8 @@ import android.hardware.SensorManager
 import androidx.core.graphics.drawable.IconCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.android.gms.location.LocationServices
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
 import com.mapbox.search.MapboxSearchSdk
 import com.mapbox.search.SearchEngineSettings
 import dagger.Module
@@ -39,6 +41,9 @@ import javax.inject.Singleton
 object AppModule {
     @Provides
     fun provideAppContext(@ApplicationContext context: Context) = context
+
+    @Provides
+    fun provideFirebaseAuth() = Firebase.auth
 
     @Provides
     @Singleton

--- a/app/src/main/java/illyan/jay/di/AppModule.kt
+++ b/app/src/main/java/illyan/jay/di/AppModule.kt
@@ -34,6 +34,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import illyan.jay.BuildConfig
 import illyan.jay.R
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import javax.inject.Singleton
 
 @Module
@@ -81,4 +84,14 @@ object AppModule {
     @Singleton
     fun provideFavoritesDataProvider() =
         MapboxSearchSdk.serviceProvider.favoritesDataProvider()
+
+    @Provides
+    @CoroutineScopeIO
+    fun provideCoroutineScopeIO() = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Provides
+    @CoroutineScopeMain
+    fun provideCoroutineScopeMain() = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 }
+
+

--- a/app/src/main/java/illyan/jay/di/CoroutineScopeQualifier.kt
+++ b/app/src/main/java/illyan/jay/di/CoroutineScopeQualifier.kt
@@ -16,16 +16,14 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package illyan.jay.data.disk.model
+package illyan.jay.di
 
-import kotlinx.serialization.Serializable
+import javax.inject.Qualifier
 
-@Serializable
-data class AppSettings(
-    val turnOnFreeDriveAutomatically: Boolean = false,
-    val clientUUID: String? = null
-) {
-    companion object {
-        val default = AppSettings()
-    }
-}
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CoroutineScopeIO
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CoroutineScopeMain

--- a/app/src/main/java/illyan/jay/domain/interactor/LocationInteractor.kt
+++ b/app/src/main/java/illyan/jay/domain/interactor/LocationInteractor.kt
@@ -19,7 +19,15 @@
 package illyan.jay.domain.interactor
 
 import illyan.jay.data.disk.datasource.LocationDiskDataSource
+import illyan.jay.data.network.datasource.LocationNetworkDataSource
+import illyan.jay.di.CoroutineScopeIO
 import illyan.jay.domain.model.DomainLocation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -33,11 +41,14 @@ import javax.inject.Singleton
 @Singleton
 class LocationInteractor @Inject constructor(
     private val locationDiskDataSource: LocationDiskDataSource,
+    private val locationNetworkDataSource: LocationNetworkDataSource,
+    private val authInteractor: AuthInteractor,
+    @CoroutineScopeIO private val coroutineScopeIO: CoroutineScope,
 ) {
     /**
      * Get latest (most up to date) locations as a Flow for a particular session.
      *
-     * @param sessionId particular session's ID, which is the
+     * @param sessionUUID particular session's ID, which is the
      * foreign key of location data returned.
      * @param limit number of latest location data returned in order from
      * the freshest location to older location data.
@@ -45,20 +56,37 @@ class LocationInteractor @Inject constructor(
      * @return location data flow for a particular session in order from
      * the freshest location to older location data.
      */
-    fun getLatestLocations(sessionId: Long, limit: Long) =
-        locationDiskDataSource.getLatestLocations(sessionId, limit)
+    fun getLatestLocations(sessionUUID: String, limit: Long): Flow<List<DomainLocation>> {
+        return locationDiskDataSource.getLatestLocations(sessionUUID, limit)
+    }
 
     fun getLatestLocations(limit: Long) = locationDiskDataSource.getLatestLocations(limit)
 
     /**
      * Get locations' data as a Flow for a particular session.
      *
-     * @param sessionId particular session's ID, which is the
+     * @param sessionUUID particular session's ID, which is the
      * foreign key of location data returned.
      *
      * @return location data flow for a particular session.
      */
-    fun getLocations(sessionId: Long) = locationDiskDataSource.getLocations(sessionId)
+    fun getLocations(sessionUUID: String) = locationDiskDataSource.getLocations(sessionUUID)
+
+    fun getLocations(sessionUUIDs: List<String>) = locationDiskDataSource.getLocations(sessionUUIDs)
+
+    fun getSyncedPath(sessionUUID: String) = getSyncedPaths(listOf(sessionUUID))
+
+    fun getSyncedPaths(sessionUUIDs: List<String>): StateFlow<List<DomainLocation>?> {
+        val syncedPaths = MutableStateFlow<List<DomainLocation>?>(null)
+        if (authInteractor.isUserSignedIn) {
+            locationNetworkDataSource.getLocations(sessionUUIDs) { remoteLocations ->
+                syncedPaths.value = remoteLocations
+            }
+        } else {
+            syncedPaths.value = emptyList()
+        }
+        return syncedPaths.asStateFlow()
+    }
 
     /**
      * Save location's data to Room database.
@@ -76,8 +104,12 @@ class LocationInteractor @Inject constructor(
      *
      * @param locations list of location data saved onto the Room database.
      */
-    fun saveLocations(locations: List<DomainLocation>) =
-        locationDiskDataSource.saveLocations(locations)
+    fun saveLocations(locations: List<DomainLocation>) {
+        coroutineScopeIO.launch {
+            locationDiskDataSource.saveLocations(locations)
+        }
+    }
+
 
     companion object {
         const val LOCATION_REQUEST_INTERVAL_REALTIME = 200L

--- a/app/src/main/java/illyan/jay/domain/interactor/SessionInteractor.kt
+++ b/app/src/main/java/illyan/jay/domain/interactor/SessionInteractor.kt
@@ -201,7 +201,6 @@ class SessionInteractor @Inject constructor(
         sessionDiskDataSource.refreshSessionUUIDs(sessions, authInteractor.userUUID!!)
     }
 
-
     fun uploadSession(
         session: DomainSession,
         locations: List<DomainLocation>,

--- a/app/src/main/java/illyan/jay/domain/model/DomainLocation.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainLocation.kt
@@ -40,7 +40,7 @@ import java.time.ZonedDateTime
  */
 data class DomainLocation(
     val id: Long = -1,
-    var sessionId: Int,
+    var sessionUUID: String,
     val zonedDateTime: ZonedDateTime,
     val latitude: Float,
     val longitude: Float,
@@ -49,8 +49,8 @@ data class DomainLocation(
     var bearing: Short = Short.MIN_VALUE, // TODO: may change Short to Byte?
     var bearingAccuracy: Short = Short.MIN_VALUE, // in degrees
     var altitude: Short = Short.MIN_VALUE,
-    var speedAccuracy: Byte = Byte.MIN_VALUE, // in meters per second
-    var verticalAccuracy: Short = Short.MIN_VALUE // in meters
+    var speedAccuracy: Float = Float.NaN, // in meters per second
+    var verticalAccuracy: Short = Short.MIN_VALUE, // in meters
 ) {
     val latLng = LatLng(latitude.toDouble(), longitude.toDouble())
 }

--- a/app/src/main/java/illyan/jay/domain/model/DomainLocation.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainLocation.kt
@@ -40,13 +40,13 @@ import java.time.ZonedDateTime
  */
 data class DomainLocation(
     val id: Long = -1,
-    val sessionId: Int,
+    var sessionId: Int,
     val zonedDateTime: ZonedDateTime,
     val latitude: Float,
     val longitude: Float,
     var speed: Float = Float.NaN,
     var accuracy: Byte = Byte.MIN_VALUE,
-    var bearing: Short = Short.MIN_VALUE,
+    var bearing: Short = Short.MIN_VALUE, // TODO: may change Short to Byte?
     var bearingAccuracy: Short = Short.MIN_VALUE, // in degrees
     var altitude: Short = Short.MIN_VALUE,
     var speedAccuracy: Byte = Byte.MIN_VALUE, // in meters per second

--- a/app/src/main/java/illyan/jay/domain/model/DomainSensorEvent.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainSensorEvent.kt
@@ -25,7 +25,7 @@ import java.time.ZonedDateTime
  * between DataSources, Interactors and Presenters.
  *
  * @property id
- * @property sessionId
+ * @property sessionUUID
  * @property zonedDateTime
  * @property accuracy
  * @property x
@@ -35,7 +35,7 @@ import java.time.ZonedDateTime
  */
 data class DomainSensorEvent(
     val id: Long = -1,
-    val sessionId: Int,
+    val sessionUUID: String,
     val zonedDateTime: ZonedDateTime,
     val accuracy: Byte, // enum
     val x: Float,

--- a/app/src/main/java/illyan/jay/domain/model/DomainSession.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainSession.kt
@@ -32,14 +32,17 @@ import java.time.ZonedDateTime
  */
 data class DomainSession(
     val id: Long = -1,
+    var uuid: String? = null,
     val startDateTime: ZonedDateTime,
     var endDateTime: ZonedDateTime?,
     var startLocationLatitude: Float? = null,
     var startLocationLongitude: Float? = null,
     var endLocationLatitude: Float? = null,
     var endLocationLongitude: Float? = null,
+    // These are optional values for an already ended session
     var startLocationName: String? = null,
-    var endLocationName: String? = null
+    var endLocationName: String? = null,
+    var distance: Float? = null,
 ) {
     var startLocation: LatLng?
         get() {

--- a/app/src/main/java/illyan/jay/domain/model/DomainSession.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainSession.kt
@@ -31,8 +31,7 @@ import java.time.ZonedDateTime
  * @constructor Create empty Domain session
  */
 data class DomainSession(
-    val id: Long = -1,
-    var uuid: String? = null,
+    var uuid: String,
     val startDateTime: ZonedDateTime,
     var endDateTime: ZonedDateTime?,
     var startLocationLatitude: Float? = null,
@@ -43,7 +42,12 @@ data class DomainSession(
     var startLocationName: String? = null,
     var endLocationName: String? = null,
     var distance: Float? = null,
+    var ownerUserUUID: String? = null,
+    var clientUUID: String? = null,
+    val isSynced: Boolean = false
 ) {
+    val isOwned = ownerUserUUID != null
+
     var startLocation: LatLng?
         get() {
             return if (startLocationLatitude != null && startLocationLongitude != null) {

--- a/app/src/main/java/illyan/jay/service/listener/JaySensorEventListener.kt
+++ b/app/src/main/java/illyan/jay/service/listener/JaySensorEventListener.kt
@@ -44,8 +44,8 @@ class JaySensorEventListener @Inject constructor(
     override fun onSensorChanged(event: SensorEvent?) {
         event?.let {
             val sensorEvents = mutableListOf<DomainSensorEvent>()
-            ongoingSessionIds.forEach { sessionId ->
-                sensorEvents += it.toDomainModel(sessionId)
+            ongoingSessionUUIDs.forEach { sessionUUID ->
+                sensorEvents += it.toDomainModel(sessionUUID)
             }
             // Saving data for each session
             scope.launch { sensorEventInteractor.saveSensorEvents(sensorEvents) }

--- a/app/src/main/java/illyan/jay/service/listener/LocationEventListener.kt
+++ b/app/src/main/java/illyan/jay/service/listener/LocationEventListener.kt
@@ -59,9 +59,9 @@ class LocationEventListener @Inject constructor(
                     scope.launch {
                         // Saving locations for every ongoing session
                         val locations = mutableListOf<DomainLocation>()
-                        ongoingSessionIds.forEach { sessionId ->
+                        ongoingSessionUUIDs.forEach { sessionUUID ->
                             locationResult.lastLocation?.let { lastLocation ->
-                                locations += lastLocation.toDomainModel(sessionId)
+                                locations += lastLocation.toDomainModel(sessionUUID)
                             }
                         }
                         locationInteractor.saveLocations(locations)

--- a/app/src/main/java/illyan/jay/service/listener/SessionSensorEventListener.kt
+++ b/app/src/main/java/illyan/jay/service/listener/SessionSensorEventListener.kt
@@ -47,12 +47,12 @@ abstract class SessionSensorEventListener(
      * IDs of ongoing sessions. Needed to be private to ensure safety
      * from ConcurrentModificationExceptions.
      */
-    private val _ongoingSessionIds = mutableListOf<Long>()
+    private val _ongoingSessionIds = mutableListOf<String>()
 
     /**
      * Needed to guarantee safety from ConcurrentModificationExceptions.
      */
-    protected val ongoingSessionIds get() = _ongoingSessionIds.toList()
+    protected val ongoingSessionUUIDs get() = _ongoingSessionIds.toList()
 
     init {
         scope.launch {
@@ -64,7 +64,7 @@ abstract class SessionSensorEventListener(
      * Load ongoing session IDs with IO context on a non UI thread.
      */
     private suspend fun loadOngoingSessionIds() = withContext(Dispatchers.IO) {
-        sessionInteractor.getOngoingSessionIds()
+        sessionInteractor.getOngoingSessionUUIDs()
             .flowOn(Dispatchers.IO)
             .collect {
                 _ongoingSessionIds.clear()

--- a/app/src/main/java/illyan/jay/ui/home/Home.kt
+++ b/app/src/main/java/illyan/jay/ui/home/Home.kt
@@ -1090,11 +1090,11 @@ private fun SheetNavHost(
                     height >= sheetMinHeight &&
                     height != sheetState.getOffsetAsDp(density)
                 ) {
-                    Timber.d(
-                        "Density: ${density}\n" +
-                                "New bottom sheet height: ${sheetState.getOffsetAsDp(density)}\n" +
-                                "Bottom sheet state:\n${sheetState.asString()}"
-                    )
+//                    Timber.d(
+//                        "Density: ${density}\n" +
+//                                "New bottom sheet height: ${sheetState.getOffsetAsDp(density)}\n" +
+//                                "Bottom sheet state:\n${sheetState.asString()}"
+//                    )
                     refreshCameraPadding()
                 }
                 layout(placeable.width, placeable.height) {

--- a/app/src/main/java/illyan/jay/ui/profile/Profile.kt
+++ b/app/src/main/java/illyan/jay/ui/profile/Profile.kt
@@ -18,6 +18,7 @@
 
 package illyan.jay.ui.profile
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
@@ -47,6 +48,7 @@ fun ProfileScreen(
     if (isDialogOpen) {
         val isUserSignedIn by viewModel.isUserSignedIn.collectAsState()
         var showDialog by remember { mutableStateOf(false) }
+        val isUserSigningOut by viewModel.isUserSigningOut.collectAsState()
         AlertDialog(
             properties = DialogProperties(
                 usePlatformDefaultWidth = false
@@ -54,13 +56,20 @@ fun ProfileScreen(
             onDismissRequest = { onDialogClosed() },
             title = { Text(text = stringResource(R.string.profile)) },
             confirmButton = {
-                if (isUserSignedIn) {
-                    TextButton(onClick = { viewModel.signOut() }) {
-                        Text(text = stringResource(R.string.sign_out))
-                    }
-                } else {
-                    Button(onClick = { showDialog = true }) {
-                        Text(text = stringResource(R.string.sign_in))
+                Crossfade(targetState = isUserSignedIn) {
+                    if (it) {
+                        TextButton(
+                            enabled = !isUserSigningOut,
+                            onClick = { viewModel.signOut() }
+                        ) {
+                            Text(text = stringResource(R.string.sign_out))
+                        }
+                    } else {
+                        Button(
+                            onClick = { showDialog = true }
+                        ) {
+                            Text(text = stringResource(R.string.sign_in))
+                        }
                     }
                 }
             },

--- a/app/src/main/java/illyan/jay/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/illyan/jay/ui/profile/ProfileViewModel.kt
@@ -28,6 +28,6 @@ class ProfileViewModel @Inject constructor(
     private val authInteractor: AuthInteractor
 ): ViewModel() {
     val isUserSignedIn = authInteractor.isUserSignedInStateFlow
-
+    val isUserSigningOut = authInteractor.isUserSigningOut
     fun signOut() = authInteractor.signOut()
 }

--- a/app/src/main/java/illyan/jay/ui/session/Session.kt
+++ b/app/src/main/java/illyan/jay/ui/session/Session.kt
@@ -18,6 +18,7 @@
 
 package illyan.jay.ui.session
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -25,6 +26,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowRightAlt
@@ -43,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.mapbox.geojson.Point
@@ -77,40 +80,38 @@ fun SessionScreen(
     LaunchedEffect(Unit) {
         viewModel.load(sessionUUID)
     }
-    val session by viewModel.session.collectAsState()
     var sheetHeightNotSet by remember { mutableStateOf(true) }
-    val isLoadingFromNetwork by viewModel.isLoadingSessionFromNetwork.collectAsState()
-    var sessionLoaded by remember { mutableStateOf(false) }
+    var pathLoaded by remember { mutableStateOf(false) }
+    val path by viewModel.path.collectAsState()
     LaunchedEffect(
-        session,
+        path,
         sheetState.isAnimationRunning,
-        isLoadingFromNetwork
     ) {
-        session?.let {
-            if (!sessionLoaded) {
+        path?.let {
+            if (!pathLoaded) {
                 tryFlyToPath(
-                    path = it.locations.map { location ->
+                    path = path!!.map { location ->
                         Point.fromLngLat(
                             location.latLng.longitude,
                             location.latLng.latitude
                         )
                     },
-                    extraCondition = { !sheetHeightNotSet || isLoadingFromNetwork },
-                    onFly = { sessionLoaded = true }
+                    extraCondition = { !sheetHeightNotSet && !sheetState.isAnimationRunning },
+                    onFly = { pathLoaded = true }
                 )
+                sheetHeightNotSet = false
             }
-            sheetHeightNotSet = false
         }
     }
     DisposableEffect(
-        session
+        path
     ) {
         val annotationsPlugin = mapView.value?.annotations
         val polylineAnnotationManager = annotationsPlugin?.createPolylineAnnotationManager()
         polylineAnnotationManager?.create(
             option = PolylineAnnotationOptions()
                 .withPoints(
-                    session?.locations?.map {
+                    path?.map {
                         Point.fromLngLat(it.latLng.longitude, it.latLng.latitude)
                     } ?: emptyList()
                 )
@@ -122,6 +123,19 @@ fun SessionScreen(
             annotationsPlugin?.removeAnnotationManager(polylineAnnotationManager!!)
         }
     }
+    SessionDetailsScreen(
+        viewModel = viewModel
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SessionDetailsScreen(
+    viewModel: SessionViewModel = hiltViewModel(),
+) {
+    val isPathLoadingFromNetwork by viewModel.isLoadingSessionFromNetwork.collectAsState()
+    val session by viewModel.session.collectAsState()
+    val path by viewModel.path.collectAsState()
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -129,41 +143,58 @@ fun SessionScreen(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Text(
-                text = session?.startLocationName ?: stringResource(R.string.unknown),
-                style = MaterialTheme.typography.titleLarge
-            )
-            Icon(imageVector = Icons.Rounded.ArrowRightAlt, contentDescription = "")
-            Crossfade(targetState = session?.endDateTime == null) {
-                if (it) {
-                    Icon(imageVector = Icons.Rounded.MoreHoriz, contentDescription = "")
-                } else {
-                    Text(
-                        text = session?.endLocationName ?: stringResource(R.string.unknown),
-                        style = MaterialTheme.typography.titleLarge
-                    )
+            Row(
+                modifier = Modifier.padding(4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = session?.startLocationName ?: stringResource(R.string.unknown),
+                    style = MaterialTheme.typography.titleLarge
+                )
+                Icon(imageVector = Icons.Rounded.ArrowRightAlt, contentDescription = "")
+                Crossfade(targetState = session?.endDateTime == null) {
+                    if (it) {
+                        Icon(imageVector = Icons.Rounded.MoreHoriz, contentDescription = "")
+                    } else {
+                        Text(
+                            text = session?.endLocationName ?: stringResource(R.string.unknown),
+                            style = MaterialTheme.typography.titleLarge
+                        )
+                    }
                 }
+            }
+            AnimatedVisibility(
+                visible = isPathLoadingFromNetwork && (path == null || session == null)
+            ) {
+                CircularProgressIndicator()
             }
         }
         Column {
             Text(
                 text = "${stringResource(R.string.distance)}: " +
-                        "${session?.totalDistance?.div(1000)?.toBigDecimal()?.setScale(2, RoundingMode.FLOOR) ?:
-                        stringResource(R.string.unknown)} " +
-                        stringResource(R.string.meters)
+                        if (session?.totalDistance == null) {
+                            stringResource(R.string.unknown)
+                        } else {
+                            "${session!!.totalDistance!!
+                                .div(1000)
+                                .toBigDecimal()
+                                .setScale(2, RoundingMode.FLOOR)} " +
+                                    stringResource(R.string.kilometers)
+                        }
             )
             Text(
                 text = "${stringResource(R.string.duration)}: " +
-                        session?.duration?.format(
+                        (session?.duration?.format(
                             separator = " ",
                             second = stringResource(R.string.second_short),
                             minute = stringResource(R.string.minute_short),
                             hour = stringResource(R.string.hour_short),
                             day = stringResource(R.string.day_short)
                         )
+                            ?: stringResource(R.string.unknown))
             )
         }
     }

--- a/app/src/main/java/illyan/jay/ui/session/Session.kt
+++ b/app/src/main/java/illyan/jay/ui/session/Session.kt
@@ -69,20 +69,22 @@ import java.math.RoundingMode
 @Destination
 @Composable
 fun SessionScreen(
-    sessionId: Long,
+    sessionUUID: String,
     viewModel: SessionViewModel = hiltViewModel(),
     destinationsNavigator: DestinationsNavigator = EmptyDestinationsNavigator
 ) {
     SheetScreenBackPressHandler(destinationsNavigator = destinationsNavigator)
     LaunchedEffect(Unit) {
-        viewModel.load(sessionId)
+        viewModel.load(sessionUUID)
     }
     val session by viewModel.session.collectAsState()
     var sheetHeightNotSet by remember { mutableStateOf(true) }
+    val isLoadingFromNetwork by viewModel.isLoadingSessionFromNetwork.collectAsState()
     var sessionLoaded by remember { mutableStateOf(false) }
     LaunchedEffect(
         session,
-        sheetState.isAnimationRunning
+        sheetState.isAnimationRunning,
+        isLoadingFromNetwork
     ) {
         session?.let {
             if (!sessionLoaded) {
@@ -93,7 +95,7 @@ fun SessionScreen(
                             location.latLng.latitude
                         )
                     },
-                    extraCondition = { !sheetHeightNotSet },
+                    extraCondition = { !sheetHeightNotSet || isLoadingFromNetwork },
                     onFly = { sessionLoaded = true }
                 )
             }

--- a/app/src/main/java/illyan/jay/ui/session/model/UiLocation.kt
+++ b/app/src/main/java/illyan/jay/ui/session/model/UiLocation.kt
@@ -30,7 +30,7 @@ data class UiLocation(
     var bearing: Short,
     var bearingAccuracy: Short, // in degrees
     var altitude: Short,
-    var speedAccuracy: Byte, // in meters per second
+    var speedAccuracy: Float, // in meters per second
     var verticalAccuracy: Short, // in meters
 )
 

--- a/app/src/main/java/illyan/jay/ui/session/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/session/model/UiSession.kt
@@ -27,7 +27,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 data class UiSession(
-    val id: Long,
+    val uuid: String,
     val startDateTime: ZonedDateTime,
     val endDateTime: ZonedDateTime?,
     val startCoordinate: LatLng?,
@@ -48,7 +48,7 @@ fun DomainSession.toUiModel(
     }
     val sortedLocationLatLngs = sortedLocations.map { it.latLng }
     return UiSession(
-        id = id,
+        uuid = uuid,
         startDateTime = startDateTime,
         endDateTime = endDateTime,
         startCoordinate = sortedLocationLatLngs.firstOrNull(),

--- a/app/src/main/java/illyan/jay/ui/session/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/session/model/UiSession.kt
@@ -19,8 +19,6 @@
 package illyan.jay.ui.session.model
 
 import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.ktx.utils.sphericalPathLength
-import illyan.jay.domain.model.DomainLocation
 import illyan.jay.domain.model.DomainSession
 import java.time.ZonedDateTime
 import kotlin.time.Duration
@@ -32,31 +30,24 @@ data class UiSession(
     val endDateTime: ZonedDateTime?,
     val startCoordinate: LatLng?,
     val endCoordinate: LatLng?,
-    val totalDistance: Double,
+    val totalDistance: Float?,
     val startLocationName: String?,
     val endLocationName: String?,
-    val locations: List<UiLocation>,
     val duration: Duration
 )
 
 fun DomainSession.toUiModel(
-    locations: List<DomainLocation>,
     currentTime: ZonedDateTime = ZonedDateTime.now(),
 ): UiSession {
-    val sortedLocations = locations.sortedBy {
-        it.zonedDateTime.toInstant().toEpochMilli()
-    }
-    val sortedLocationLatLngs = sortedLocations.map { it.latLng }
     return UiSession(
         uuid = uuid,
         startDateTime = startDateTime,
         endDateTime = endDateTime,
-        startCoordinate = sortedLocationLatLngs.firstOrNull(),
-        endCoordinate = sortedLocationLatLngs.lastOrNull(),
-        totalDistance = sortedLocationLatLngs.sphericalPathLength(),
+        startCoordinate = startLocation,
+        endCoordinate = endLocation,
+        totalDistance = distance,
         startLocationName = startLocationName,
         endLocationName = endLocationName,
-        locations = sortedLocations.map { it.toUiModel() },
         duration = if (endDateTime != null) {
             (endDateTime!!.toInstant().toEpochMilli() - startDateTime.toInstant().toEpochMilli())
                 .milliseconds

--- a/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
@@ -30,7 +30,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowRightAlt
+import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.CloudSync
+import androidx.compose.material.icons.rounded.CloudUpload
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.LibraryAdd
 import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.rounded.PersonOff
 import androidx.compose.material.icons.rounded.Save
@@ -41,6 +45,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -100,24 +105,54 @@ fun SessionsScreen(
         modifier = Modifier.padding(DefaultScreenOnSheetPadding)
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            Button(
+            TextButton(
                 onClick = { viewModel.syncSessions() },
-                enabled = isUserSignedIn
+                enabled = isUserSignedIn,
             ) {
-                Text(text = "Sync sessions to the cloud!")
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(imageVector = Icons.Rounded.CloudUpload, contentDescription = "")
+                    Text(text = stringResource(R.string.sync))
+                }
             }
-            Button(
+            TextButton(
                 onClick = { viewModel.deleteAllSyncedData() },
-                enabled = isUserSignedIn
+                enabled = isUserSignedIn,
             ) {
-                Text(text = "PURGE IT ALL (in the cloud)!")
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(imageVector = Icons.Rounded.CloudOff, contentDescription = "")
+                    Text(text = stringResource(R.string.local_only))
+                }
             }
-            Button(
+            TextButton(
                 onClick = { viewModel.deleteSessionsLocally() },
             ) {
-                Text(text = "PURGE IT ALL (locally)!")
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(imageVector = Icons.Rounded.Delete, contentDescription = "")
+                    Text(text = stringResource(R.string.delete_locally))
+                }
+            }
+            TextButton(
+                onClick = { viewModel.ownAllSessions() },
+                enabled = isUserSignedIn,
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(imageVector = Icons.Rounded.LibraryAdd, contentDescription = "")
+                    Text(text = stringResource(R.string.own_all_sessions))
+                }
             }
         }
         SessionsList(
@@ -176,8 +211,16 @@ fun SessionsList(
                 }
             ) {
                 if (session != null && session!!.isNotOwned && isUserSignedIn) {
-                    Button(onClick = { viewModel.ownSession(session!!.uuid) }) {
-                        Text(text = "Own this session!")
+                    Button(
+                        onClick = { viewModel.ownSession(session!!.uuid) },
+                    ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(imageVector = Icons.Rounded.MoreHoriz, contentDescription = "")
+                            Text(text = stringResource(R.string.own_session))
+                        }
                     }
                 }
             }
@@ -190,7 +233,7 @@ fun SessionsList(
 @Composable
 fun SessionCard(
     modifier: Modifier = Modifier,
-    session: UiSession?,
+    session: UiSession? = null,
     onClick: (String) -> Unit = {},
     content: @Composable () -> Unit = {}
 ) {
@@ -253,19 +296,26 @@ fun SessionCard(
                 Column {
                     Text(
                         text = "${stringResource(R.string.distance)}: " +
-                                "${session?.totalDistance?.div(1000)?.toBigDecimal()?.setScale(2, RoundingMode.FLOOR) ?:
-                                stringResource(R.string.unknown)} " +
-                                stringResource(R.string.kilometers)
+                                if (session == null) {
+                                    stringResource(R.string.unknown)
+                                } else {
+                                    "${session.totalDistance
+                                        .div(1000)
+                                        .toBigDecimal()
+                                        .setScale(2, RoundingMode.FLOOR)} " +
+                                            stringResource(R.string.kilometers)
+                                }
                     )
                     Text(
                         text = "${stringResource(R.string.duration)}: " +
-                                session?.duration?.format(
+                                (session?.duration?.format(
                                     separator = " ",
                                     second = stringResource(R.string.second_short),
                                     minute = stringResource(R.string.minute_short),
                                     hour = stringResource(R.string.hour_short),
                                     day = stringResource(R.string.day_short)
                                 )
+                                    ?: stringResource(R.string.unknown))
                     )
                 }
                 content()

--- a/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
@@ -29,12 +29,12 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AddChart
 import androidx.compose.material.icons.rounded.ArrowRightAlt
 import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.CloudSync
 import androidx.compose.material.icons.rounded.CloudUpload
 import androidx.compose.material.icons.rounded.Delete
-import androidx.compose.material.icons.rounded.LibraryAdd
 import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.rounded.PersonOff
 import androidx.compose.material.icons.rounded.Save
@@ -150,7 +150,7 @@ fun SessionsScreen(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(imageVector = Icons.Rounded.LibraryAdd, contentDescription = "")
+                    Icon(imageVector = Icons.Rounded.AddChart, contentDescription = "")
                     Text(text = stringResource(R.string.own_all_sessions))
                 }
             }

--- a/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
@@ -30,7 +30,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowRightAlt
+import androidx.compose.material.icons.rounded.CloudSync
 import androidx.compose.material.icons.rounded.MoreHoriz
+import androidx.compose.material.icons.rounded.PersonOff
+import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -47,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.placeholder.PlaceholderHighlight
@@ -86,17 +90,17 @@ fun SessionsScreen(
 ) {
     SheetScreenBackPressHandler(destinationsNavigator = destinationsNavigator)
     val context = LocalContext.current
-    LaunchedEffect(Unit) {
-        viewModel.load(context)
+    val signedInUser by viewModel.signedInUser.collectAsState()
+    LaunchedEffect(signedInUser) {
+        viewModel.loadLocalSessions()
+        viewModel.loadCloudSessions(context)
     }
     val isUserSignedIn by viewModel.isUserSignedIn.collectAsState()
     Column(
         modifier = Modifier.padding(DefaultScreenOnSheetPadding)
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+        Column(
+            modifier = Modifier.fillMaxWidth()
         ) {
             Button(
                 onClick = { viewModel.syncSessions() },
@@ -108,7 +112,12 @@ fun SessionsScreen(
                 onClick = { viewModel.deleteAllSyncedData() },
                 enabled = isUserSignedIn
             ) {
-                Text(text = "PURGE IT ALL!")
+                Text(text = "PURGE IT ALL (in the cloud)!")
+            }
+            Button(
+                onClick = { viewModel.deleteSessionsLocally() },
+            ) {
+                Text(text = "PURGE IT ALL (locally)!")
             }
         }
         SessionsList(
@@ -132,26 +141,24 @@ fun SessionsList(
     viewModel: SessionsViewModel = hiltViewModel(),
     destinationsNavigator: DestinationsNavigator,
 ) {
-    val sessionIds by viewModel.sessionIds.collectAsState()
-    val syncedSessions by viewModel.syncedSessions.collectAsState()
+    val localSessionUUIDs by viewModel.localSessionUUIDs.collectAsState()
+    val remoteSessions by viewModel.syncedSessions.collectAsState()
+    val isUserSignedIn by viewModel.isUserSignedIn.collectAsState()
     LazyColumn(
         modifier = modifier,
         contentPadding = DefaultContentPadding,
         verticalArrangement = Arrangement.spacedBy(MenuItemPadding)
     ) {
-        item {
-            Text(text = "Synced sessions")
-        }
-        items(syncedSessions) {
+        items(remoteSessions) {
             SessionCard(
                 modifier = Modifier.fillMaxWidth(),
-                session = it
+                session = it,
+                onClick = { sessionUUID ->
+                    destinationsNavigator.navigate(SessionScreenDestination(sessionUUID = sessionUUID))
+                }
             )
         }
-        item {
-            Text(text = "Local sessions")
-        }
-        items(sessionIds) {
+        items(localSessionUUIDs) {
             val session by viewModel.getSessionStateFlow(it).collectAsState()
             val isPlaceholderVisible = session == null
             val placeholderHighlight = PlaceholderHighlight.shimmer()
@@ -164,27 +171,35 @@ fun SessionsList(
                         shape = RoundedCornerShape(12.dp)
                     ),
                 session = session,
-                onClick = { id ->
-                    destinationsNavigator.navigate(SessionScreenDestination(id))
+                onClick = { sessionUUID ->
+                    destinationsNavigator.navigate(SessionScreenDestination(sessionUUID = sessionUUID))
                 }
-            )
+            ) {
+                if (session != null && session!!.isNotOwned && isUserSignedIn) {
+                    Button(onClick = { viewModel.ownSession(session!!.uuid) }) {
+                        Text(text = "Own this session!")
+                    }
+                }
+            }
         }
     }
 }
 
+@Preview(showBackground = true)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SessionCard(
     modifier: Modifier = Modifier,
     session: UiSession?,
-    onClick: (Long) -> Unit = {},
+    onClick: (String) -> Unit = {},
+    content: @Composable () -> Unit = {}
 ) {
     val cardColors = CardDefaults.cardColors(
         containerColor = Neutral95
     )
     Card(
         modifier = modifier,
-        onClick = { session?.let { onClick(it.id) } },
+        onClick = { session?.let { onClick(it.uuid) } },
         colors = cardColors,
     ) {
         Column(
@@ -194,42 +209,66 @@ fun SessionCard(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text(
-                    text = session?.startLocationName ?: stringResource(R.string.unknown),
-                    style = MaterialTheme.typography.titleLarge
-                )
-                Icon(imageVector = Icons.Rounded.ArrowRightAlt, contentDescription = "")
-                Crossfade(targetState = session?.endDateTime == null) {
-                    if (it) {
-                        Icon(imageVector = Icons.Rounded.MoreHoriz, contentDescription = "")
-                    } else {
-                        Text(
-                            text = session?.endLocationName ?: stringResource(R.string.unknown),
-                            style = MaterialTheme.typography.titleLarge
-                        )
+                Row(
+                    modifier = Modifier.padding(4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = session?.startLocationName ?: stringResource(R.string.unknown),
+                        style = MaterialTheme.typography.titleLarge
+                    )
+                    Icon(imageVector = Icons.Rounded.ArrowRightAlt, contentDescription = "")
+                    Crossfade(targetState = session?.endDateTime == null) {
+                        if (it) {
+                            Icon(imageVector = Icons.Rounded.MoreHoriz, contentDescription = "")
+                        } else {
+                            Text(
+                                text = session?.endLocationName ?: stringResource(R.string.unknown),
+                                style = MaterialTheme.typography.titleLarge
+                            )
+                        }
+                    }
+                }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    if (session?.isLocal == true) {
+                        Icon(imageVector = Icons.Rounded.Save, contentDescription = "")
+                    }
+                    if (session?.isSynced == true) {
+                        Icon(imageVector = Icons.Rounded.CloudSync, contentDescription = "")
+                    }
+                    if (session?.isNotOwned == true) {
+                        Icon(imageVector = Icons.Rounded.PersonOff, contentDescription = "")
                     }
                 }
             }
-            Column {
-                Text(
-                    text = "${stringResource(R.string.distance)}: " +
-                            "${session?.totalDistance?.div(1000)?.toBigDecimal()?.setScale(2, RoundingMode.FLOOR) ?:
-                            stringResource(R.string.unknown)} " +
-                            stringResource(R.string.kilometers)
-                )
-                Text(
-                    text = "${stringResource(R.string.duration)}: " +
-                            session?.duration?.format(
-                                separator = " ",
-                                second = stringResource(R.string.second_short),
-                                minute = stringResource(R.string.minute_short),
-                                hour = stringResource(R.string.hour_short),
-                                day = stringResource(R.string.day_short)
-                            )
-                )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column {
+                    Text(
+                        text = "${stringResource(R.string.distance)}: " +
+                                "${session?.totalDistance?.div(1000)?.toBigDecimal()?.setScale(2, RoundingMode.FLOOR) ?:
+                                stringResource(R.string.unknown)} " +
+                                stringResource(R.string.kilometers)
+                    )
+                    Text(
+                        text = "${stringResource(R.string.duration)}: " +
+                                session?.duration?.format(
+                                    separator = " ",
+                                    second = stringResource(R.string.second_short),
+                                    minute = stringResource(R.string.minute_short),
+                                    hour = stringResource(R.string.hour_short),
+                                    day = stringResource(R.string.day_short)
+                                )
+                    )
+                }
+                content()
             }
         }
     }

--- a/app/src/main/java/illyan/jay/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/SessionsViewModel.kt
@@ -61,8 +61,8 @@ class SessionsViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Eagerly, "")
 
     private val _syncedSessions = MutableStateFlow(listOf<DomainSession>())
-    val syncedSessions = _syncedSessions.combine(clientUUID) { sessions, clientUUID -> sessions.map { it.toUiModel(currentClientUUID = clientUUID) } }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, _syncedSessions.value.map { it.toUiModel(currentClientUUID = clientUUID.value) })
+    val syncedSessions = _syncedSessions.combine(clientUUID) { sessions, clientUUID -> sessions.map { it.toUiModel(currentClientUUID = clientUUID, isLocal = false) } }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, _syncedSessions.value.map { it.toUiModel(currentClientUUID = clientUUID.value, isLocal = false) })
 
     fun loadLocalSessions() {
         viewModelScope.launch(Dispatchers.IO) {
@@ -125,7 +125,7 @@ class SessionsViewModel @Inject constructor(
                         sessionInteractor.refreshSessionEndLocation(session)
                     }
                     locationInteractor.getLocations(sessionUUDI).collectLatest {
-                        sessionMutableStateFlow.value = session.toUiModel(it, clientUUID.value)
+                        sessionMutableStateFlow.value = session.toUiModel(it, clientUUID.value, true)
                     }
                 }
             }

--- a/app/src/main/java/illyan/jay/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/SessionsViewModel.kt
@@ -26,110 +26,120 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import illyan.jay.domain.interactor.AuthInteractor
 import illyan.jay.domain.interactor.LocationInteractor
 import illyan.jay.domain.interactor.SessionInteractor
+import illyan.jay.domain.interactor.SettingsInteractor
 import illyan.jay.domain.model.DomainSession
 import illyan.jay.ui.sessions.model.UiSession
 import illyan.jay.ui.sessions.model.toUiModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class SessionsViewModel @Inject constructor(
     private val sessionInteractor: SessionInteractor,
     private val locationInteractor: LocationInteractor,
-    private val authInteractor: AuthInteractor
+    private val authInteractor: AuthInteractor,
+    private val settingsInteractor: SettingsInteractor
 ) : ViewModel() {
-    private val sessionStateFlows = mutableMapOf<Long, StateFlow<UiSession?>>()
+    private val sessionStateFlows = mutableMapOf<String, StateFlow<UiSession?>>()
 
-    private val _sessionIds = MutableStateFlow(listOf<Long>())
-    val sessionIds = _sessionIds.asStateFlow()
+    private val _sessionUUIDs = MutableStateFlow(listOf<String>())
+    val localSessionUUIDs = _sessionUUIDs.asStateFlow()
 
     val isUserSignedIn = authInteractor.isUserSignedInStateFlow
+    val signedInUser = authInteractor.currentUserStateFlow
+
+    private val clientUUID = settingsInteractor.appSettingsFlow.map { it.clientUUID ?: "" }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, "")
 
     private val _syncedSessions = MutableStateFlow(listOf<DomainSession>())
-    val syncedSessions = _syncedSessions.map { sessions -> sessions.map { it.toUiModel() } }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, _syncedSessions.value.map { it.toUiModel() })
+    val syncedSessions = _syncedSessions.combine(clientUUID) { sessions, clientUUID -> sessions.map { it.toUiModel(currentClientUUID = clientUUID) } }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, _syncedSessions.value.map { it.toUiModel(currentClientUUID = clientUUID.value) })
 
-    fun load(context: Context) {
-        viewModelScope.launch {
-            sessionInteractor.getLocalOnlySessionIds().collectLatest {
-                _sessionIds.value = it.sortedDescending()
+    fun loadLocalSessions() {
+        viewModelScope.launch(Dispatchers.IO) {
+            sessionInteractor.getLocalOnlySessionUUIDs().collectLatest {
+                _sessionUUIDs.value = it.asReversed()
             }
         }
-        viewModelScope.launch {
-            sessionInteractor.getSyncedSessions(
-                (context as Activity)
-            ) {
-                Timber.d("Got sessions from Firebase, size = ${it.size}")
-                _syncedSessions.value = it
+    }
+
+    fun loadCloudSessions(context: Context) {
+        viewModelScope.launch(Dispatchers.IO) {
+            sessionInteractor.syncSessions((context as Activity))
+            sessionInteractor.syncedSessions.collectLatest {
+                _syncedSessions.value = it ?: emptyList()
             }
         }
     }
 
     fun deleteAllSyncedData() {
-        viewModelScope.launch {
-            sessionInteractor.deleteAllSyncedData(viewModelScope)
+        viewModelScope.launch(Dispatchers.IO) {
+            sessionInteractor.deleteAllSyncedData()
         }
     }
 
+    fun ownSession(sessionUUID: String) {
+        sessionInteractor.ownSession(sessionUUID)
+    }
+
+    fun ownAllSessions() {
+        sessionInteractor.ownAllNotOwnedSessions()
+    }
+
     fun syncSessions() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             sessionInteractor.getSessions().first { sessions ->
-                sessions.forEach {
-                    if (it.uuid == null) {
-                        viewModelScope.launch {
-                            locationInteractor.getLocations(it.id).first { locations ->
-                                sessionInteractor.uploadSession(
-                                    it to locations,
-                                    viewModelScope
-                                )
-                                locations.isNotEmpty()
-                            }
-                        }
+                viewModelScope.launch(Dispatchers.IO) {
+                    locationInteractor.getLocations(sessions.map { it.uuid }).first { locations ->
+                        sessionInteractor.uploadSessions(
+                            sessions,
+                            locations,
+                        )
+                        true
                     }
                 }
-                sessions.isNotEmpty()
+                true
             }
         }
     }
 
-    fun getSessionStateFlow(sessionId: Long): StateFlow<UiSession?> {
-        if (sessionStateFlows.contains(sessionId)) {
-            return sessionStateFlows[sessionId]!!
+    fun deleteSessionsLocally() {
+        sessionInteractor.deleteStoppedSessions()
+    }
+
+    fun getSessionStateFlow(sessionUUDI: String): StateFlow<UiSession?> {
+        if (sessionStateFlows.contains(sessionUUDI)) {
+            return sessionStateFlows[sessionUUDI]!!
         }
         val sessionMutableStateFlow = MutableStateFlow<UiSession?>(null)
         val sessionStateFlow = sessionMutableStateFlow.asStateFlow()
-        sessionStateFlows[sessionId] = sessionStateFlow
+        sessionStateFlows[sessionUUDI] = sessionStateFlow
 
-        viewModelScope.launch {
-            sessionInteractor.getSession(sessionId).collectLatest { session ->
+        viewModelScope.launch(Dispatchers.IO) {
+            sessionInteractor.getSession(sessionUUDI).collectLatest { session ->
                 session?.let {
                     if (session.startLocation == null ||
                         session.startLocationName == null
                     ) {
-                        sessionInteractor.refreshSessionStartLocation(
-                            session,
-                            viewModelScope
-                        )
+                        sessionInteractor.refreshSessionStartLocation(session)
                     }
                     if (session.endDateTime != null &&
                         (session.endLocation == null || session.endLocationName == null)
                     ) {
-                        sessionInteractor.refreshSessionEndLocation(
-                            session,
-                            viewModelScope
-                        )
+                        sessionInteractor.refreshSessionEndLocation(session)
                     }
-                    locationInteractor.getLocations(sessionId).collectLatest {
-                        sessionMutableStateFlow.value = session.toUiModel(it)
+                    locationInteractor.getLocations(sessionUUDI).collectLatest {
+                        sessionMutableStateFlow.value = session.toUiModel(it, clientUUID.value)
                     }
                 }
             }

--- a/app/src/main/java/illyan/jay/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/SessionsViewModel.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -75,7 +74,7 @@ class SessionsViewModel @Inject constructor(
 
     fun loadCloudSessions(context: Context) {
         viewModelScope.launch(Dispatchers.IO) {
-            sessionInteractor.syncSessions((context as Activity))
+            sessionInteractor.loadSyncedSessions((context as Activity))
             sessionInteractor.syncedSessions.collectLatest {
                 _syncedSessions.value = it ?: emptyList()
             }
@@ -97,20 +96,7 @@ class SessionsViewModel @Inject constructor(
     }
 
     fun syncSessions() {
-        viewModelScope.launch(Dispatchers.IO) {
-            sessionInteractor.getSessions().first { sessions ->
-                viewModelScope.launch(Dispatchers.IO) {
-                    locationInteractor.getLocations(sessions.map { it.uuid }).first { locations ->
-                        sessionInteractor.uploadSessions(
-                            sessions,
-                            locations,
-                        )
-                        true
-                    }
-                }
-                true
-            }
-        }
+        sessionInteractor.uploadNotSyncedSessions()
     }
 
     fun deleteSessionsLocally() {

--- a/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
@@ -44,11 +44,13 @@ data class UiSession(
 fun DomainSession.toUiModel(
     locations: List<DomainLocation>,
     currentClientUUID: String,
+    isLocal: Boolean = clientUUID == currentClientUUID,
     currentTime: ZonedDateTime = ZonedDateTime.now(),
 ): UiSession {
     return toUiModel(
         locations.sphericalPathLength(),
         currentClientUUID,
+        isLocal,
         currentTime
     )
 }
@@ -56,6 +58,7 @@ fun DomainSession.toUiModel(
 fun DomainSession.toUiModel(
     totalDistance: Double = distance?.toDouble() ?: -1.0,
     currentClientUUID: String,
+    isLocal: Boolean = clientUUID == currentClientUUID,
     currentTime: ZonedDateTime = ZonedDateTime.now(),
 ): UiSession {
     return UiSession(
@@ -75,7 +78,7 @@ fun DomainSession.toUiModel(
                 .milliseconds
         },
         isSynced = isSynced,
-        isLocal = clientUUID == currentClientUUID,
+        isLocal = isLocal,
         isNotOwned = ownerUserUUID == null
     )
 }

--- a/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
@@ -74,7 +74,7 @@ fun DomainSession.toUiModel(
             (currentTime.toInstant().toEpochMilli() - startDateTime.toInstant().toEpochMilli())
                 .milliseconds
         },
-        isSynced = clientUUID != currentClientUUID || isSynced,
+        isSynced = isSynced,
         isLocal = clientUUID == currentClientUUID,
         isNotOwned = ownerUserUUID == null
     )

--- a/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
@@ -45,13 +45,23 @@ fun DomainSession.toUiModel(
     val sortedLocations = locations.sortedBy {
         it.zonedDateTime.toInstant().toEpochMilli()
     }.map { it.latLng }
+    return toUiModel(
+        sortedLocations.sphericalPathLength(),
+        currentTime
+    )
+}
+
+fun DomainSession.toUiModel(
+    totalDistance: Double = distance?.toDouble() ?: -1.0,
+    currentTime: ZonedDateTime = ZonedDateTime.now(),
+): UiSession {
     return UiSession(
         id = id,
         startDateTime = startDateTime,
         endDateTime = endDateTime,
-        startCoordinate = sortedLocations.firstOrNull(),
-        endCoordinate = sortedLocations.lastOrNull(),
-        totalDistance = sortedLocations.sphericalPathLength(),
+        startCoordinate = startLocation,
+        endCoordinate = endLocation,
+        totalDistance = totalDistance,
         startLocationName = startLocationName,
         endLocationName = endLocationName,
         duration = if (endDateTime != null) {

--- a/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
@@ -19,15 +19,15 @@
 package illyan.jay.ui.sessions.model
 
 import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.ktx.utils.sphericalPathLength
 import illyan.jay.domain.model.DomainLocation
 import illyan.jay.domain.model.DomainSession
+import illyan.jay.util.sphericalPathLength
 import java.time.ZonedDateTime
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 data class UiSession(
-    val id: Long,
+    val uuid: String,
     val startDateTime: ZonedDateTime,
     val endDateTime: ZonedDateTime?,
     val startCoordinate: LatLng?,
@@ -35,28 +35,31 @@ data class UiSession(
     val totalDistance: Double,
     val startLocationName: String?,
     val endLocationName: String?,
-    val duration: Duration
+    val duration: Duration,
+    val isLocal: Boolean,
+    val isSynced: Boolean,
+    val isNotOwned: Boolean
 )
 
 fun DomainSession.toUiModel(
     locations: List<DomainLocation>,
+    currentClientUUID: String,
     currentTime: ZonedDateTime = ZonedDateTime.now(),
 ): UiSession {
-    val sortedLocations = locations.sortedBy {
-        it.zonedDateTime.toInstant().toEpochMilli()
-    }.map { it.latLng }
     return toUiModel(
-        sortedLocations.sphericalPathLength(),
+        locations.sphericalPathLength(),
+        currentClientUUID,
         currentTime
     )
 }
 
 fun DomainSession.toUiModel(
     totalDistance: Double = distance?.toDouble() ?: -1.0,
+    currentClientUUID: String,
     currentTime: ZonedDateTime = ZonedDateTime.now(),
 ): UiSession {
     return UiSession(
-        id = id,
+        uuid = uuid,
         startDateTime = startDateTime,
         endDateTime = endDateTime,
         startCoordinate = startLocation,
@@ -71,5 +74,8 @@ fun DomainSession.toUiModel(
             (currentTime.toInstant().toEpochMilli() - startDateTime.toInstant().toEpochMilli())
                 .milliseconds
         },
+        isSynced = clientUUID != currentClientUUID || isSynced,
+        isLocal = clientUUID == currentClientUUID,
+        isNotOwned = ownerUserUUID == null
     )
 }

--- a/app/src/main/java/illyan/jay/util/Util.kt
+++ b/app/src/main/java/illyan/jay/util/Util.kt
@@ -31,8 +31,10 @@ import androidx.compose.ui.unit.LayoutDirection
 import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.GeoPoint
+import com.google.maps.android.ktx.utils.sphericalPathLength
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
+import illyan.jay.domain.model.DomainLocation
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
@@ -118,3 +120,7 @@ fun LatLng.toGeoPoint() = GeoPoint(latitude, longitude)
 fun Timestamp.toInstant(): Instant = Instant.ofEpochSecond(seconds, nanoseconds.toLong())
 
 fun Timestamp.toZonedDateTime() = toInstant().atZone(ZoneOffset.UTC)
+
+fun List<DomainLocation>.sphericalPathLength() = sortedBy {
+    it.zonedDateTime.toInstant().toEpochMilli()
+}.map { it.latLng }.sphericalPathLength()

--- a/app/src/main/java/illyan/jay/util/Util.kt
+++ b/app/src/main/java/illyan/jay/util/Util.kt
@@ -28,9 +28,14 @@ import androidx.compose.material.BottomSheetState
 import androidx.compose.material.BottomSheetValue
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.unit.LayoutDirection
+import com.google.android.gms.maps.model.LatLng
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.GeoPoint
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -103,3 +108,13 @@ operator fun PaddingValues.plus(paddingValues: PaddingValues): PaddingValues {
         bottom = calculateBottomPadding() + paddingValues.calculateBottomPadding(),
     )
 }
+
+fun Instant.toTimestamp() = Timestamp(epochSecond, nano)
+
+fun ZonedDateTime.toTimestamp() = toInstant().toTimestamp()
+
+fun LatLng.toGeoPoint() = GeoPoint(latitude, longitude)
+
+fun Timestamp.toInstant(): Instant = Instant.ofEpochSecond(seconds, nanoseconds.toLong())
+
+fun Timestamp.toZonedDateTime() = toInstant().atZone(ZoneOffset.UTC)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,4 +56,10 @@
     <string name="sign_out">Sign out</string>
     <string name="close">Close</string>
     <string name="sign_in">Sign in</string>
+    <string name="sync">Sync</string>
+    <string name="cloud_only">Cloud only</string>
+    <string name="local_only">Local only</string>
+    <string name="delete_locally">Delete locally</string>
+    <string name="own_all_sessions">Own all sessions</string>
+    <string name="own_session">Own session</string>
 </resources>

--- a/app/src/test/java/illyan/jay/data/disk/SensorEventDiskDataSourceTest.kt
+++ b/app/src/test/java/illyan/jay/data/disk/SensorEventDiskDataSourceTest.kt
@@ -143,7 +143,7 @@ class SensorEventDiskDataSourceTest : TestBase() {
         // Wait coroutine to collect the data.
         advanceUntilIdle()
 
-        assertEquals(accelerations.filter { it.sessionId == sessionId }, result)
+        assertEquals(accelerations.filter { it.sessionUUID == sessionId }, result)
         verify(exactly = 1) { mockedDao.getSensorEvents(sessionId) }
     }
 

--- a/app/src/test/java/illyan/jay/data/disk/SessionDiskDataSourceTest.kt
+++ b/app/src/test/java/illyan/jay/data/disk/SessionDiskDataSourceTest.kt
@@ -169,7 +169,7 @@ class SessionDiskDataSourceTest : TestBase() {
     @ExperimentalCoroutinesApi
     @Test
     fun `Get ongoing session ids`() = runTest {
-        every { mockedDao.getOngoingSessionIds() } returns flowOf(
+        every { mockedDao.getOngoingSessionUUIDs() } returns flowOf(
             roomSessions.filter { it.endDateTime == null }.map { it.id }
         )
 
@@ -180,7 +180,7 @@ class SessionDiskDataSourceTest : TestBase() {
         advanceUntilIdle()
 
         assertEquals(sessions.filter { it.endDateTime == null }.map { it.id }, result)
-        verify(exactly = 1) { mockedDao.getOngoingSessionIds() }
+        verify(exactly = 1) { mockedDao.getOngoingSessionUUIDs() }
     }
 
     @Test

--- a/app/src/test/java/illyan/jay/interactor/SessionInteractorTest.kt
+++ b/app/src/test/java/illyan/jay/interactor/SessionInteractorTest.kt
@@ -178,7 +178,7 @@ class SessionInteractorTest : TestBase() {
         )
 
         var result = listOf<Long>()
-        sessionInteractor.getOngoingSessionIds().collect { result = it }
+        sessionInteractor.getOngoingSessionUUIDs().collect { result = it }
 
         // Wait coroutine to collect the data.
         advanceUntilIdle()


### PR DESCRIPTION
- Jay app can now sync sessions and the path taken associated with it to Firebase Firestore (but cannot sync sensor events yet).
- Multiple users on a single device can persist without too much overlap. This enables several use-cases for businesses, one of which using a singular device to track a bus, while having multiple driver during the day and supervising their performance and routes.
- App can be used without any accounts freely, this way you cannot own sessions, as they require a UUID which is given by Firebase. The only thing which is a maintenance cost is using Mapbox's services, but those are not essential for device tracking and features planned for Jay, like onboard (offline) ML analytics.