### PR TITLE
Toggling sensitive info visibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,6 +123,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout-compose:1.0.1"
     implementation "androidx.compose.foundation:foundation:$compose_version"
 
+    // TODO: implement some way to use bio auth
+    // Biometric Auth
+    //implementation "androidx.biometric:biometric:1.2.0-alpha05"
+
     // Material design icons
     implementation "androidx.compose.material:material-icons-core:$compose_version"
     implementation "androidx.compose.material:material-icons-extended:$compose_version"

--- a/app/src/main/java/illyan/jay/MainActivity.kt
+++ b/app/src/main/java/illyan/jay/MainActivity.kt
@@ -20,10 +20,10 @@ package illyan.jay
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
@@ -40,7 +40,7 @@ import illyan.jay.ui.theme.JayTheme
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
 
     @Inject
     lateinit var authInteractor: AuthInteractor

--- a/app/src/main/java/illyan/jay/ui/profile/Profile.kt
+++ b/app/src/main/java/illyan/jay/ui/profile/Profile.kt
@@ -18,6 +18,7 @@
 
 package illyan.jay.ui.profile
 
+import android.content.Context
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
@@ -27,8 +28,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Lock
+import androidx.compose.material.icons.rounded.LockOpen
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -37,6 +43,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,6 +52,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
+import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import illyan.jay.R
 import illyan.jay.ui.home.AvatarAsyncImage
@@ -97,6 +105,7 @@ fun ProfileDialog(
             },
             text = {
                 ProfileDetailsScreen(
+                    context = context,
                     viewModel = viewModel
                 )
             }
@@ -133,21 +142,166 @@ fun ProfileTitleScreen(
 @Composable
 fun ProfileDetailsScreen(
     viewModel: ProfileViewModel = hiltViewModel(),
+    context: Context,
 ) {
     val email by viewModel.userEmail.collectAsState()
     val phone by viewModel.userPhoneNumber.collectAsState()
     val name by viewModel.userName.collectAsState()
-    Column(
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+    var showConfidentialInfo by remember { mutableStateOf(false) }
+    var authenticated by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        AnimatedVisibility(visible = name != null) {
-            Text(text = stringResource(R.string.name) + ": " + name)
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            AnimatedVisibility(visible = !name.isNullOrBlank()) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(text = stringResource(R.string.name) + ": ")
+                    Text(
+                        text = if (showConfidentialInfo) {
+                            name ?: stringResource(R.string.unknown)
+                        } else {
+                            stringResource(R.string.hidden_field_string)
+                        }
+                    )
+                }
+            }
+            AnimatedVisibility(visible = !email.isNullOrBlank()) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(text = stringResource(R.string.email) + ": ")
+                    Text(
+                        text = if (showConfidentialInfo) {
+                            email ?: stringResource(R.string.unknown)
+                        } else {
+                            stringResource(R.string.hidden_field_string)
+                        }
+                    )
+                }
+            }
+            AnimatedVisibility(visible = !phone.isNullOrBlank()) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(text = stringResource(R.string.phone_number) + ": ")
+                    Text(
+                        text = if (showConfidentialInfo) {
+                            name ?: stringResource(R.string.unknown)
+                        } else {
+                            stringResource(R.string.hidden_field_string)
+                        }
+                    )
+                }
+            }
         }
-        AnimatedVisibility(visible = email != null) {
-            Text(text = stringResource(R.string.email) + ": " + email)
+        val anyConfidentialInfo = !name.isNullOrBlank() ||
+                !email.isNullOrBlank() ||
+                !phone.isNullOrBlank()
+        AnimatedVisibility(visible = anyConfidentialInfo) {
+            IconButton(
+                onClick = {
+                    toggleConfidentialInfoVisibility(
+                        showConfidentialInfo = showConfidentialInfo,
+                        authenticated = authenticated,
+                        fragmentActivity = context as FragmentActivity,
+                        onAuthenticationChanged = { authenticated = it },
+                        onInfoVisibilityChanged = { showConfidentialInfo = it }
+                    )
+                }
+            ) {
+                Icon(
+                    imageVector = if (showConfidentialInfo) {
+                        Icons.Rounded.LockOpen
+                    } else {
+                        Icons.Rounded.Lock
+                    },
+                    contentDescription = ""
+                )
+            }
         }
-        AnimatedVisibility(visible = phone != null) {
-            Text(text = stringResource(R.string.phone_number) + ": " + phone)
+    }
+}
+
+fun toggleConfidentialInfoVisibility(
+    showConfidentialInfo: Boolean,
+    authenticated: Boolean,
+    fragmentActivity: FragmentActivity,
+    onAuthenticationChanged: (Boolean) -> Unit,
+    onInfoVisibilityChanged: (Boolean) -> Unit,
+) {
+    if (showConfidentialInfo) {
+        onInfoVisibilityChanged(false)
+    } else {
+        if (authenticated) {
+            onInfoVisibilityChanged(true)
+        } else {
+            onInfoVisibilityChanged(true)
+            onAuthenticationChanged(true)
+            // TODO: implement some kind of biometric authentication with multiple local users
+            //  in mind. As a phone can be used by multiple people, using biometrics and other
+            //  local authentication, authentication should be independent from the device itself.
+            //  Though this problem is solved by Firebase Auth. Maybe simply hiding the fields is
+            //  enough for now.
+//            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+//                val biometricManager = BiometricManager.from(fragmentActivity)
+//                when (biometricManager.canAuthenticate(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)) {
+//                    BiometricManager.BIOMETRIC_SUCCESS ->
+//                        Timber.d("App can authenticate using biometrics.")
+//                    BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE ->
+//                        Timber.e("No biometric features available on this device.")
+//                    BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE ->
+//                        Timber.e("Biometric features are currently unavailable.")
+//                    BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> {
+//                        // Prompts the user to create credentials that your app accepts.
+//                        val enrollIntent = Intent(ACTION_BIOMETRIC_ENROLL).apply {
+//                            putExtra(EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED,
+//                                BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
+//                        }
+//                        fragmentActivity.startActivityForResult(enrollIntent, 0)
+//                    }
+//                }
+//                val biometricPrompt = BiometricPrompt(
+//                    fragmentActivity,
+//                    object : BiometricPrompt.AuthenticationCallback() {
+//                        override fun onAuthenticationSucceeded(
+//                            result: BiometricPrompt.AuthenticationResult,
+//                        ) {
+//                            super.onAuthenticationSucceeded(result)
+//                            onAuthenticationChanged(true)
+//                            onInfoVisibilityChanged(true)
+//                        }
+//                        override fun onAuthenticationFailed() {
+//                            super.onAuthenticationFailed()
+//                            Timber.d("Authentication failed!")
+//                        }
+//                        override fun onAuthenticationError(
+//                            errorCode: Int,
+//                            errString: CharSequence
+//                        ) {
+//                            super.onAuthenticationError(errorCode, errString)
+//                            Timber.d("Authentication error code: $errorCode\n" +
+//                                    "Error message: $errString")
+//                        }
+//                    })
+//                val promptTitle = fragmentActivity.getString(R.string.show_profile_info)
+//                val promptSubtitle =
+//                    fragmentActivity.getString(R.string.authenticate_to_view_account_information)
+//                val promptInfo = BiometricPrompt.PromptInfo.Builder()
+//                    .setTitle(promptTitle)
+//                    .setSubtitle(promptSubtitle)
+//                    .setAllowedAuthenticators(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
+//                    .build()
+//                biometricPrompt.authenticate(promptInfo)
+//            } else {
+//                // TODO: make this compatible down to API 21
+//                onAuthenticationChanged(true)
+//            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,4 +76,7 @@
     <string name="bute">Budapest University of Technology and Economics</string>
     <string name="phone_number">Phone number</string>
     <string name="name">Name</string>
+    <string name="authenticate_to_view_account_information">Authenticate to view account information</string>
+    <string name="show_profile_info">Show profile info</string>
+    <string name="hidden_field_string">********</string>
 </resources>


### PR DESCRIPTION
Hidden sensitive information on ProfileDialog. User can toggle information visibility with the lock button. Biometric authentication may be used in the future, but code is commented out, because it won't solve the current problem.

Biometric authentication is not used because multiple users can use a single device, thus that device's authentication capabilities will not meet requirements to identify several other users. Device independent authentication should be used. Firebase already solves our authentication problem and the real problem is to hide sensitive data from a single user when their phone gets compromised. When multiple users are present, user may be more causious with how they are handling their accounts on the device.

Though maybe an automatic logoff timer will solve the privacy problem if one forgets to log out by themselves.