### PR TITLE
#37 refactor sessions management and screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+  ~ Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
   ~
   ~ Jay is a driver behaviour analytics app.
   ~
@@ -18,6 +18,8 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature android:name="android.hardware.telephony" />
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/app/src/main/java/illyan/jay/MainActivity.kt
+++ b/app/src/main/java/illyan/jay/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -25,7 +25,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -59,9 +58,7 @@ class MainActivity : AppCompatActivity() {
         setContent {
             JayTheme {
                 MainScreen(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .statusBarsPadding()
+                    modifier = Modifier.fillMaxSize()
                 )
             }
         }

--- a/app/src/main/java/illyan/jay/data/disk/JayDatabase.kt
+++ b/app/src/main/java/illyan/jay/data/disk/JayDatabase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -39,7 +39,7 @@ import illyan.jay.data.disk.model.RoomSession
         RoomLocation::class,
         RoomSensorEvent::class
     ],
-    version = 24,
+    version = 27,
     exportSchema = false
 )
 abstract class JayDatabase : RoomDatabase() {

--- a/app/src/main/java/illyan/jay/data/disk/JayDatabase.kt
+++ b/app/src/main/java/illyan/jay/data/disk/JayDatabase.kt
@@ -39,7 +39,7 @@ import illyan.jay.data.disk.model.RoomSession
         RoomLocation::class,
         RoomSensorEvent::class
     ],
-    version = 28,
+    version = 29,
     exportSchema = false
 )
 abstract class JayDatabase : RoomDatabase() {

--- a/app/src/main/java/illyan/jay/data/disk/JayDatabase.kt
+++ b/app/src/main/java/illyan/jay/data/disk/JayDatabase.kt
@@ -39,7 +39,7 @@ import illyan.jay.data.disk.model.RoomSession
         RoomLocation::class,
         RoomSensorEvent::class
     ],
-    version = 27,
+    version = 28,
     exportSchema = false
 )
 abstract class JayDatabase : RoomDatabase() {

--- a/app/src/main/java/illyan/jay/data/disk/Mapping.kt
+++ b/app/src/main/java/illyan/jay/data/disk/Mapping.kt
@@ -31,7 +31,6 @@ import illyan.jay.domain.model.DomainSession
 import illyan.jay.util.sensorTimestampToAbsoluteTime
 import java.time.Instant
 import java.time.ZoneOffset
-import java.util.UUID
 
 // Session
 fun RoomSession.toDomainModel() = DomainSession(
@@ -66,12 +65,11 @@ fun DomainSession.toRoomModel() = RoomSession(
 
 // Location
 fun RoomLocation.toDomainModel() = DomainLocation(
-    uuid = uuid,
     latitude = latitude,
+    zonedDateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC),
     longitude = longitude,
     speed = speed,
     sessionUUID = sessionUUID,
-    zonedDateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC),
     accuracy = accuracy,
     bearing = bearing,
     bearingAccuracy = bearingAccuracy,
@@ -81,11 +79,11 @@ fun RoomLocation.toDomainModel() = DomainLocation(
 )
 
 fun DomainLocation.toRoomModel() = RoomLocation(
+    sessionUUID = sessionUUID,
+    time = zonedDateTime.toInstant().toEpochMilli(),
     latitude = latitude,
     longitude = longitude,
     speed = speed,
-    sessionUUID = sessionUUID,
-    time = zonedDateTime.toInstant().toEpochMilli(),
     accuracy = accuracy,
     bearing = bearing,
     bearingAccuracy = bearingAccuracy,
@@ -98,11 +96,10 @@ fun Location.toDomainModel(
     sessionUUID: String
 ): DomainLocation {
     val domainLocation = DomainLocation(
-        uuid = UUID.randomUUID().toString(),
-        latitude = latitude.toFloat(),
-        longitude = longitude.toFloat(),
+        sessionUUID = sessionUUID,
         zonedDateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC),
-        sessionUUID = sessionUUID
+        latitude = latitude.toFloat(),
+        longitude = longitude.toFloat()
     )
 
     if (hasSpeed()) domainLocation.speed = speed
@@ -120,7 +117,6 @@ fun Location.toDomainModel(
 
 // Rotation
 fun RoomSensorEvent.toDomainModel() = DomainSensorEvent(
-    uuid = uuid,
     zonedDateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC),
     sessionUUID = sessionUUID,
     accuracy = accuracy,
@@ -131,23 +127,22 @@ fun RoomSensorEvent.toDomainModel() = DomainSensorEvent(
 )
 
 fun DomainSensorEvent.toRoomModel() = RoomSensorEvent(
-    time = zonedDateTime.toInstant().toEpochMilli(),
     sessionUUID = sessionUUID,
+    time = zonedDateTime.toInstant().toEpochMilli(),
+    type = type,
     accuracy = accuracy,
     x = x,
     y = y,
-    z = z,
-    type = type
+    z = z
 )
 
 // Sensors
 fun SensorEvent.toDomainModel(sessionUUID: String) = DomainSensorEvent(
-    uuid = UUID.randomUUID().toString(),
     sessionUUID = sessionUUID,
     zonedDateTime = Instant.ofEpochMilli(sensorTimestampToAbsoluteTime(timestamp)).atZone(ZoneOffset.UTC),
+    type = sensor.type.toByte(),
     accuracy = accuracy.toByte(),
     x = values[0],
     y = values[1],
-    z = values[2],
-    type = sensor.type.toByte()
+    z = values[2]
 )

--- a/app/src/main/java/illyan/jay/data/disk/Mapping.kt
+++ b/app/src/main/java/illyan/jay/data/disk/Mapping.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -31,6 +31,7 @@ import illyan.jay.domain.model.DomainSession
 import illyan.jay.util.sensorTimestampToAbsoluteTime
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.UUID
 
 // Session
 fun RoomSession.toDomainModel() = DomainSession(
@@ -46,7 +47,6 @@ fun RoomSession.toDomainModel() = DomainSession(
     distance = distance,
     ownerUserUUID = ownerUserUUID,
     clientUUID = clientUUID,
-    isSynced = isSynced,
 )
 
 fun DomainSession.toRoomModel() = RoomSession(
@@ -62,12 +62,11 @@ fun DomainSession.toRoomModel() = RoomSession(
     distance = distance,
     ownerUserUUID = ownerUserUUID,
     clientUUID = clientUUID,
-    isSynced = isSynced,
 )
 
 // Location
 fun RoomLocation.toDomainModel() = DomainLocation(
-    id = id,
+    uuid = uuid,
     latitude = latitude,
     longitude = longitude,
     speed = speed,
@@ -99,6 +98,7 @@ fun Location.toDomainModel(
     sessionUUID: String
 ): DomainLocation {
     val domainLocation = DomainLocation(
+        uuid = UUID.randomUUID().toString(),
         latitude = latitude.toFloat(),
         longitude = longitude.toFloat(),
         zonedDateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC),
@@ -120,7 +120,7 @@ fun Location.toDomainModel(
 
 // Rotation
 fun RoomSensorEvent.toDomainModel() = DomainSensorEvent(
-    id = id,
+    uuid = uuid,
     zonedDateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC),
     sessionUUID = sessionUUID,
     accuracy = accuracy,
@@ -142,6 +142,7 @@ fun DomainSensorEvent.toRoomModel() = RoomSensorEvent(
 
 // Sensors
 fun SensorEvent.toDomainModel(sessionUUID: String) = DomainSensorEvent(
+    uuid = UUID.randomUUID().toString(),
     sessionUUID = sessionUUID,
     zonedDateTime = Instant.ofEpochMilli(sensorTimestampToAbsoluteTime(timestamp)).atZone(ZoneOffset.UTC),
     accuracy = accuracy.toByte(),

--- a/app/src/main/java/illyan/jay/data/disk/Mapping.kt
+++ b/app/src/main/java/illyan/jay/data/disk/Mapping.kt
@@ -45,7 +45,7 @@ fun RoomSession.toDomainModel() = DomainSession(
     startLocationName = startLocationName,
     endLocationName = endLocationName,
     distance = distance,
-    ownerUserUUID = ownerUserUUID,
+    ownerUUID = ownerUUID,
     clientUUID = clientUUID,
 )
 
@@ -60,7 +60,7 @@ fun DomainSession.toRoomModel() = RoomSession(
     startLocationName = startLocationName,
     endLocationName = endLocationName,
     distance = distance,
-    ownerUserUUID = ownerUserUUID,
+    ownerUUID = ownerUUID,
     clientUUID = clientUUID,
 )
 

--- a/app/src/main/java/illyan/jay/data/disk/dao/LocationDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/LocationDao.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -61,8 +61,8 @@ interface LocationDao {
     fun deleteLocations(sessionUUID: String)
 
     @Transaction
-    @Query("SELECT * FROM location WHERE id = :id")
-    fun getLocation(id: Long): Flow<RoomLocation?>
+    @Query("SELECT * FROM location WHERE uuid = :uuid")
+    fun getLocation(uuid: String): Flow<RoomLocation?>
 
     @Transaction
     @Query("SELECT * FROM location WHERE sessionUUID = :sessionUUID")
@@ -73,10 +73,10 @@ interface LocationDao {
     fun getLocations(sessionUUIDs: List<String>): Flow<List<RoomLocation>>
 
     @Transaction
-    @Query("SELECT * FROM location ORDER BY id DESC LIMIT :limit")
+    @Query("SELECT * FROM location ORDER BY time DESC LIMIT :limit")
     fun getLatestLocations(limit: Long): Flow<List<RoomLocation>>
 
     @Transaction
-    @Query("SELECT * FROM location WHERE sessionUUID = :sessionUUID ORDER BY id DESC LIMIT :limit")
+    @Query("SELECT * FROM location WHERE sessionUUID = :sessionUUID ORDER BY time DESC LIMIT :limit")
     fun getLatestLocations(sessionUUID: String, limit: Long): Flow<List<RoomLocation>>
 }

--- a/app/src/main/java/illyan/jay/data/disk/dao/LocationDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/LocationDao.kt
@@ -61,10 +61,6 @@ interface LocationDao {
     fun deleteLocations(sessionUUID: String)
 
     @Transaction
-    @Query("SELECT * FROM location WHERE uuid = :uuid")
-    fun getLocation(uuid: String): Flow<RoomLocation?>
-
-    @Transaction
     @Query("SELECT * FROM location WHERE sessionUUID = :sessionUUID")
     fun getLocations(sessionUUID: String): Flow<List<RoomLocation>>
 

--- a/app/src/main/java/illyan/jay/data/disk/dao/SensorEventDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/SensorEventDao.kt
@@ -59,9 +59,6 @@ interface SensorEventDao {
     @Query("DELETE FROM sensor_events WHERE sessionUUID = :sessionUUID")
     fun deleteSensorEventsForSession(sessionUUID: String)
 
-    @Query("SELECT * FROM sensor_events WHERE uuid = :uuid")
-    fun getSensorEvent(uuid: String): Flow<RoomSensorEvent?>
-
     @Query("SELECT * FROM sensor_events WHERE sessionUUID = :sessionUUID")
     fun getSensorEvents(sessionUUID: String): Flow<List<RoomSensorEvent>>
 }

--- a/app/src/main/java/illyan/jay/data/disk/dao/SensorEventDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/SensorEventDao.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -59,8 +59,8 @@ interface SensorEventDao {
     @Query("DELETE FROM sensor_events WHERE sessionUUID = :sessionUUID")
     fun deleteSensorEventsForSession(sessionUUID: String)
 
-    @Query("SELECT * FROM sensor_events WHERE id = :id")
-    fun getSensorEvent(id: Long): Flow<RoomSensorEvent?>
+    @Query("SELECT * FROM sensor_events WHERE uuid = :uuid")
+    fun getSensorEvent(uuid: String): Flow<RoomSensorEvent?>
 
     @Query("SELECT * FROM sensor_events WHERE sessionUUID = :sessionUUID")
     fun getSensorEvents(sessionUUID: String): Flow<List<RoomSensorEvent>>

--- a/app/src/main/java/illyan/jay/data/disk/dao/SessionDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/SessionDao.kt
@@ -55,70 +55,94 @@ interface SessionDao {
     fun deleteSessions(sessions: List<RoomSession>)
 
     @Transaction
-    @Query("DELETE FROM session WHERE ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL")
-    fun deleteSessions(ownerUserUUID: String? = null)
+    @Query("DELETE FROM session WHERE ownerUUID IS :ownerUUID OR ownerUUID IS NULL")
+    fun deleteSessions(ownerUUID: String? = null)
 
     @Transaction
-    @Query("DELETE FROM session WHERE ownerUserUUID IS NULL")
+    @Query("DELETE FROM session WHERE ownerUUID IS NULL")
     fun deleteNotOwnedSessions()
 
     @Transaction
-    @Query("DELETE FROM session WHERE ownerUserUUID IS :ownerUserUUID")
-    fun deleteSessionsByOwner(ownerUserUUID: String? = null)
+    @Query("DELETE FROM session WHERE ownerUUID IS :ownerUUID")
+    fun deleteSessionsByOwner(ownerUUID: String? = null)
 
     @Transaction
-    @Query("DELETE FROM session WHERE ownerUserUUID IS :ownerUserUUID AND endDateTime IS NOT NULL")
-    fun deleteStoppedSessionsByOwner(ownerUserUUID: String? = null)
+    @Query("DELETE FROM session WHERE ownerUUID IS :ownerUUID AND endDateTime IS NOT NULL")
+    fun deleteStoppedSessionsByOwner(ownerUUID: String? = null)
 
     @Transaction
-    @Query("SELECT * FROM session WHERE ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL")
-    fun getSessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
+    @Query("SELECT * FROM session WHERE ownerUUID IS :ownerUUID OR ownerUUID IS NULL")
+    fun getSessions(ownerUUID: String? = null): Flow<List<RoomSession>>
 
     @Transaction
-    @Query("SELECT uuid FROM session WHERE ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL")
-    fun getSessionUUIDs(ownerUserUUID: String? = null): Flow<List<String>>
+    @Query("SELECT uuid FROM session WHERE ownerUUID IS :ownerUUID OR ownerUUID IS NULL")
+    fun getSessionUUIDs(ownerUUID: String? = null): Flow<List<String>>
 
     @Transaction
-    @Query("SELECT * FROM session WHERE uuid = :uuid AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL) LIMIT 1")
-    fun getSession(uuid: String, ownerUserUUID: String? = null): Flow<RoomSession?>
+    @Query("SELECT * FROM session WHERE uuid = :uuid AND (ownerUUID IS :ownerUUID OR ownerUUID IS NULL) LIMIT 1")
+    fun getSession(uuid: String, ownerUUID: String? = null): Flow<RoomSession?>
 
     @Transaction
-    @Query("SELECT * FROM session WHERE endDateTime IS NOT NULL AND ownerUserUUID IS :ownerUserUUID")
-    fun getStoppedSessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
+    @Query("SELECT * FROM session WHERE endDateTime IS NOT NULL AND ownerUUID IS :ownerUUID")
+    fun getStoppedSessions(ownerUUID: String? = null): Flow<List<RoomSession>>
 
     @Transaction
-    @Query("SELECT * FROM session WHERE endDateTime IS NULL AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL) ORDER BY startDateTime DESC")
-    fun getOngoingSessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
+    @Query("SELECT * FROM session WHERE endDateTime IS NULL AND (ownerUUID IS :ownerUUID OR ownerUUID IS NULL) ORDER BY startDateTime DESC")
+    fun getOngoingSessions(ownerUUID: String? = null): Flow<List<RoomSession>>
 
     @Transaction
-    @Query("SELECT uuid FROM session WHERE endDateTime IS NULL AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL) ORDER BY startDateTime DESC")
-    fun getOngoingSessionUUIDs(ownerUserUUID: String? = null): Flow<List<String>>
+    @Query("SELECT uuid FROM session WHERE endDateTime IS NULL AND (ownerUUID IS :ownerUUID OR ownerUUID IS NULL) ORDER BY startDateTime DESC")
+    fun getOngoingSessionUUIDs(ownerUUID: String? = null): Flow<List<String>>
 
     @Transaction
-    @Query("SELECT * FROM session WHERE ownerUserUUID IS NULL ORDER BY startDateTime DESC")
+    @Query("SELECT * FROM session WHERE ownerUUID IS NULL ORDER BY startDateTime DESC")
     fun getAllNotOwnedSessions(): Flow<List<RoomSession>>
 
     @Transaction
-    @Query("SELECT * FROM session WHERE ownerUserUUID IS :ownerUserUUID ORDER BY startDateTime DESC")
-    fun getSessionsByOwner(ownerUserUUID: String? = null): Flow<List<RoomSession>>
+    @Query("SELECT * FROM session WHERE ownerUUID IS :ownerUUID ORDER BY startDateTime DESC")
+    fun getSessionsByOwner(ownerUUID: String? = null): Flow<List<RoomSession>>
 
     @Transaction
-    @Query("UPDATE session SET ownerUserUUID = :ownerUserUUID WHERE ownerUserUUID IS NULL")
-    fun ownAllNotOwnedSessions(ownerUserUUID: String): Int
+    @Query("UPDATE session SET ownerUUID = :ownerUUID WHERE ownerUUID IS NULL")
+    fun ownAllNotOwnedSessions(ownerUUID: String): Int
 
     @Transaction
-    @Query("UPDATE session SET ownerUserUUID = :ownerUserUUID WHERE ownerUserUUID IS NULL AND uuid = :uuid")
-    fun ownNotOwnedSession(uuid: String, ownerUserUUID: String): Int
+    @Query("UPDATE session SET ownerUUID = :ownerUUID WHERE ownerUUID IS NULL AND uuid = :uuid")
+    fun ownNotOwnedSession(uuid: String, ownerUUID: String): Int
 
     @Transaction
-    @Query("UPDATE session SET ownerUserUUID = :ownerUserUUID WHERE uuid IN(:uuids)")
-    fun ownSessions(uuids: List<String>, ownerUserUUID: String)
+    @Query("UPDATE session SET ownerUUID = :ownerUUID WHERE uuid IN(:uuids)")
+    fun ownSessions(uuids: List<String>, ownerUUID: String)
 
     @Transaction
-    @Query("UPDATE session SET ownerUserUUID = NULL WHERE uuid IN(:uuids)")
+    @Query("UPDATE session SET ownerUUID = NULL WHERE uuid IN(:uuids)")
     fun disownSessions(uuids: List<String>)
 
     @Transaction
-    @Query("UPDATE session SET ownerUserUUID = NULL WHERE ownerUserUUID IS :ownerUserUUID")
-    fun disownSessions(ownerUserUUID: String)
+    @Query("UPDATE session SET ownerUUID = NULL WHERE ownerUUID IS :ownerUUID")
+    fun disownSessions(ownerUUID: String)
+
+    @Transaction
+    @Query("UPDATE session SET startLocationLatitude = :latitude, startLocationLongitude = :longitude WHERE uuid IS :sessionUUID")
+    fun saveStartLocationForSession(sessionUUID: String, latitude: Double, longitude: Double)
+
+    @Transaction
+    @Query("UPDATE session SET endLocationLatitude = :latitude, endLocationLongitude = :longitude WHERE uuid IS :sessionUUID")
+    fun saveEndLocationForSession(sessionUUID: String, latitude: Double, longitude: Double)
+
+    @Transaction
+    @Query("UPDATE session SET startLocationName = :name WHERE uuid IS :sessionUUID")
+    fun saveStartLocationNameForSession(sessionUUID: String, name: String)
+
+    @Transaction
+    @Query("UPDATE session SET endLocationName = :name WHERE uuid IS :sessionUUID")
+    fun saveEndLocationNameForSession(sessionUUID: String, name: String)
+
+    @Transaction
+    @Query("UPDATE session SET clientUUID = :clientUUID WHERE uuid IS :sessionUUID")
+    fun assignClientToSession(sessionUUID: String, clientUUID: String?)
+
+    @Transaction
+    @Query("UPDATE session SET distance = :distance WHERE uuid IS :sessionUUID")
+    fun saveDistanceForSession(sessionUUID: String, distance: Float?)
 }

--- a/app/src/main/java/illyan/jay/data/disk/dao/SessionDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/SessionDao.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -87,44 +87,20 @@ interface SessionDao {
     fun getStoppedSessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
 
     @Transaction
-    @Query("SELECT * FROM session WHERE endDateTime IS NULL AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL)")
+    @Query("SELECT * FROM session WHERE endDateTime IS NULL AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL) ORDER BY startDateTime DESC")
     fun getOngoingSessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
 
     @Transaction
-    @Query("SELECT uuid FROM session WHERE endDateTime IS NULL AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL)")
+    @Query("SELECT uuid FROM session WHERE endDateTime IS NULL AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL) ORDER BY startDateTime DESC")
     fun getOngoingSessionUUIDs(ownerUserUUID: String? = null): Flow<List<String>>
 
     @Transaction
-    @Query("SELECT uuid FROM session WHERE NOT isSynced AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL)")
-    fun getLocalOnlySessionUUIDs(ownerUserUUID: String? = null): Flow<List<String>>
-
-    @Transaction
-    @Query("SELECT uuid FROM session WHERE isSynced AND ownerUserUUID IS :ownerUserUUID")
-    fun getSyncedSessionUUIDs(ownerUserUUID: String? = null): Flow<List<String>>
-
-    @Transaction
-    @Query("SELECT * FROM session WHERE NOT isSynced AND (ownerUserUUID IS :ownerUserUUID OR ownerUserUUID IS NULL)")
-    fun getLocalOnlySessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
-
-    @Transaction
-    @Query("SELECT * FROM session WHERE isSynced AND ownerUserUUID IS :ownerUserUUID")
-    fun getSyncedSessions(ownerUserUUID: String? = null): Flow<List<RoomSession>>
-
-    @Transaction
-    @Query("SELECT * FROM session WHERE ownerUserUUID IS NULL")
+    @Query("SELECT * FROM session WHERE ownerUserUUID IS NULL ORDER BY startDateTime DESC")
     fun getAllNotOwnedSessions(): Flow<List<RoomSession>>
 
     @Transaction
-    @Query("SELECT * FROM session WHERE ownerUserUUID IS :ownerUserUUID")
+    @Query("SELECT * FROM session WHERE ownerUserUUID IS :ownerUserUUID ORDER BY startDateTime DESC")
     fun getSessionsByOwner(ownerUserUUID: String? = null): Flow<List<RoomSession>>
-
-    @Transaction
-    @Query("SELECT * FROM session WHERE ownerUserUUID IS :ownerUserUUID AND NOT isSynced")
-    fun getLocalSessionsByOwner(ownerUserUUID: String? = null): Flow<List<RoomSession>>
-
-    @Transaction
-    @Query("UPDATE session SET uuid = :newUUID WHERE uuid IS :currentUUID AND ownerUserUUID IS :ownerUserUUID")
-    fun refreshSessionUUID(currentUUID: String, newUUID: String, ownerUserUUID: String): Int
 
     @Transaction
     @Query("UPDATE session SET ownerUserUUID = :ownerUserUUID WHERE ownerUserUUID IS NULL")
@@ -133,10 +109,6 @@ interface SessionDao {
     @Transaction
     @Query("UPDATE session SET ownerUserUUID = :ownerUserUUID WHERE ownerUserUUID IS NULL AND uuid = :uuid")
     fun ownNotOwnedSession(uuid: String, ownerUserUUID: String): Int
-
-    @Transaction
-    @Query("UPDATE session SET isSynced = :isSynced WHERE uuid IN(:uuids)")
-    fun updateSyncOnSessions(uuids: List<String>, isSynced: Boolean)
 
     @Transaction
     @Query("UPDATE session SET ownerUserUUID = :ownerUserUUID WHERE uuid IN(:uuids)")

--- a/app/src/main/java/illyan/jay/data/disk/datasource/LocationDiskDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/disk/datasource/LocationDiskDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -24,6 +24,7 @@ import illyan.jay.data.disk.toDomainModel
 import illyan.jay.data.disk.toRoomModel
 import illyan.jay.domain.model.DomainLocation
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -86,8 +87,10 @@ class LocationDiskDataSource @Inject constructor(
      *
      * @param locations list of location data saved onto the Room database.
      */
-    fun saveLocations(locations: List<DomainLocation>) =
+    fun saveLocations(locations: List<DomainLocation>) {
+        Timber.d("Saving ${locations.size} locations")
         locationDao.upsertLocations(locations.map(DomainLocation::toRoomModel))
+    }
 
     fun deleteLocationForSession(sessionUUID: String) = locationDao.deleteLocations(sessionUUID)
 }

--- a/app/src/main/java/illyan/jay/data/disk/datasource/SessionDiskDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/disk/datasource/SessionDiskDataSource.kt
@@ -31,7 +31,6 @@ import java.time.ZonedDateTime
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
-
 /**
  * Session disk data source using Room to communicate with the SQLite database.
  *
@@ -58,11 +57,17 @@ class SessionDiskDataSource @Inject constructor(
     fun getSessionsByOwner(ownerUserUUID: String?) = sessionDao.getSessionsByOwner(ownerUserUUID)
         .map { it.map(RoomSession::toDomainModel) }
 
-    fun ownAllNotOwnedSessions(ownerUserUUID: String) =
+    fun ownAllNotOwnedSessions(ownerUserUUID: String) {
+        Timber.d("$ownerUserUUID owns all sessions without an owner")
         sessionDao.ownAllNotOwnedSessions(ownerUserUUID)
+    }
 
-    fun ownNotOwnedSession(sessionUUID: String, ownerUserUUID: String) =
+
+    fun ownNotOwnedSession(sessionUUID: String, ownerUserUUID: String) {
+        Timber.d("$ownerUserUUID owns session with no owner yet: $sessionUUID")
         sessionDao.ownNotOwnedSession(sessionUUID, ownerUserUUID)
+    }
+
 
     /**
      * Get a particular session by its ID.
@@ -95,7 +100,10 @@ class SessionDiskDataSource @Inject constructor(
     fun getOngoingSessionIds(ownerUserUUID: String?) =
         sessionDao.getOngoingSessionUUIDs(ownerUserUUID)
 
-    fun ownSessions(sessionUUIDs: List<String>, ownerUserUUID: String) = sessionDao.ownSessions(sessionUUIDs, ownerUserUUID)
+    fun ownSessions(sessionUUIDs: List<String>, ownerUserUUID: String) {
+        Timber.d("ownerUserUUID owns sessions: ${sessionUUIDs.map { it.take(4) }}")
+        return sessionDao.ownSessions(sessionUUIDs, ownerUserUUID)
+    }
 
     /**
      * Creates a session in the database with the current time as
@@ -130,15 +138,21 @@ class SessionDiskDataSource @Inject constructor(
      *
      * @return id of session updated.
      */
-    fun saveSession(session: DomainSession) = sessionDao.upsertSession(session.toRoomModel())
+    fun saveSession(session: DomainSession): Long {
+        Timber.d("Upserting session: ${session.uuid}")
+        return sessionDao.upsertSession(session.toRoomModel())
+    }
 
     /**
      * Save multiple sessions in the database.
      *
      * @param sessions updates the data of the sessions with the same ID.
      */
-    fun saveSessions(sessions: List<DomainSession>) =
+    fun saveSessions(sessions: List<DomainSession>) {
+        Timber.d("Upserting sessions: ${sessions.map { it.uuid.take(4) }}")
         sessionDao.upsertSessions(sessions.map(DomainSession::toRoomModel))
+    }
+
 
     /**
      * Stop a session.
@@ -172,13 +186,23 @@ class SessionDiskDataSource @Inject constructor(
         saveSessions(sessions)
     }
 
-    fun deleteSessions(sessions: List<DomainSession>) =
+    fun deleteSessions(sessions: List<DomainSession>) {
+        Timber.d("Deleting sessions: ${sessions.map { it.uuid.take(4) }}")
         sessionDao.deleteSessions(sessions.map(DomainSession::toRoomModel))
+    }
 
-    fun deleteSessionsByOwner(ownerUserUUID: String?) =
+    fun deleteSessionsByOwner(ownerUserUUID: String?) {
+        Timber.d("Deleting sessions by owner $ownerUserUUID")
         sessionDao.deleteSessionsByOwner(ownerUserUUID)
+    }
 
-    fun deleteNotOwnedSessions() = sessionDao.deleteNotOwnedSessions()
+    fun deleteNotOwnedSessions() {
+        Timber.d("Deleting not owned sessions")
+        sessionDao.deleteNotOwnedSessions()
+    }
 
-    fun deleteStoppedSessionsByOwner(ownerUserUUID: String?) = sessionDao.deleteStoppedSessionsByOwner(ownerUserUUID)
+    fun deleteStoppedSessionsByOwner(ownerUserUUID: String?) {
+        sessionDao.deleteStoppedSessionsByOwner(ownerUserUUID)
+    }
 }
+

--- a/app/src/main/java/illyan/jay/data/disk/datasource/SessionDiskDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/disk/datasource/SessionDiskDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -50,27 +50,12 @@ class SessionDiskDataSource @Inject constructor(
     fun getSessions(ownerUserUUID: String?) =
         sessionDao.getSessions(ownerUserUUID).map { it.map(RoomSession::toDomainModel) }
 
-    fun getLocalOnlySessions(ownerUserUUID: String?) =
-        sessionDao.getLocalOnlySessions(ownerUserUUID)
-            .map { it.map(RoomSession::toDomainModel) }
-
-    fun getSyncedSessions(ownerUserUUID: String) = sessionDao.getSyncedSessions(ownerUserUUID)
-        .map { it.map(RoomSession::toDomainModel) }
-
-    fun getSessionIds(ownerUserUUID: String?) = sessionDao.getSessionUUIDs(ownerUserUUID)
-
-    fun getLocalOnlySessionUUIDs(ownerUserUUID: String?) =
-        sessionDao.getLocalOnlySessionUUIDs(ownerUserUUID)
-
-    fun getSyncedSessionUUIDs(ownerUserUUID: String) = sessionDao.getSyncedSessionUUIDs(ownerUserUUID)
+    fun getSessionUUIDs(ownerUserUUID: String?) = sessionDao.getSessionUUIDs(ownerUserUUID)
 
     fun getAllNotOwnedSessions() = sessionDao.getAllNotOwnedSessions()
         .map { it.map(RoomSession::toDomainModel) }
 
     fun getSessionsByOwner(ownerUserUUID: String?) = sessionDao.getSessionsByOwner(ownerUserUUID)
-        .map { it.map(RoomSession::toDomainModel) }
-
-    fun getLocalSessionsByOwner(ownerUserUUID: String) = sessionDao.getLocalSessionsByOwner(ownerUserUUID)
         .map { it.map(RoomSession::toDomainModel) }
 
     fun ownAllNotOwnedSessions(ownerUserUUID: String) =
@@ -196,13 +181,4 @@ class SessionDiskDataSource @Inject constructor(
     fun deleteNotOwnedSessions() = sessionDao.deleteNotOwnedSessions()
 
     fun deleteStoppedSessionsByOwner(ownerUserUUID: String?) = sessionDao.deleteStoppedSessionsByOwner(ownerUserUUID)
-
-    fun refreshSessionUUIDs(sessions: List<DomainSession>, ownerUserUUID: String) =
-        sessions.forEach { refreshSessionUUID(it, ownerUserUUID) }
-
-    fun refreshSessionUUID(session: DomainSession, ownerUserUUID: String) =
-        sessionDao.refreshSessionUUID(session.uuid, session.uuid, ownerUserUUID)
-
-    fun updateSyncOnSessions(sessionUUIDs: List<String>, isSynced: Boolean) =
-        sessionDao.updateSyncOnSessions(sessionUUIDs, isSynced)
 }

--- a/app/src/main/java/illyan/jay/data/disk/model/RoomLocation.kt
+++ b/app/src/main/java/illyan/jay/data/disk/model/RoomLocation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -22,6 +22,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(
     tableName = "location",
@@ -35,8 +36,8 @@ import androidx.room.PrimaryKey
     indices = [Index(value = ["sessionUUID"])]
 )
 data class RoomLocation(
-    @PrimaryKey(autoGenerate = true)
-    val id: Long = 0,
+    @PrimaryKey
+    val uuid: String = UUID.randomUUID().toString(),
     val sessionUUID: String,
     val latitude: Float,
     val longitude: Float,

--- a/app/src/main/java/illyan/jay/data/disk/model/RoomLocation.kt
+++ b/app/src/main/java/illyan/jay/data/disk/model/RoomLocation.kt
@@ -21,8 +21,6 @@ package illyan.jay.data.disk.model
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
-import androidx.room.PrimaryKey
-import java.util.UUID
 
 @Entity(
     tableName = "location",
@@ -33,16 +31,15 @@ import java.util.UUID
             childColumns = ["sessionUUID"]
         )
     ],
-    indices = [Index(value = ["sessionUUID"])]
+    indices = [Index(value = ["sessionUUID"])],
+    primaryKeys = ["sessionUUID", "time"]
 )
 data class RoomLocation(
-    @PrimaryKey
-    val uuid: String = UUID.randomUUID().toString(),
     val sessionUUID: String,
+    val time: Long, // in millis
     val latitude: Float,
     val longitude: Float,
     val accuracy: Byte,
-    val time: Long, // in millis
     val speed: Float,
     val speedAccuracy: Float, // in meters per second
     val bearing: Short,

--- a/app/src/main/java/illyan/jay/data/disk/model/RoomSensorEvent.kt
+++ b/app/src/main/java/illyan/jay/data/disk/model/RoomSensorEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -22,6 +22,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(
     tableName = "sensor_events",
@@ -35,8 +36,8 @@ import androidx.room.PrimaryKey
     indices = [Index(value = ["sessionUUID"]), Index(value = ["time"])]
 )
 data class RoomSensorEvent(
-    @PrimaryKey(autoGenerate = true)
-    val id: Long = 0,
+    @PrimaryKey
+    val uuid: String = UUID.randomUUID().toString(),
     val sessionUUID: String,
     val time: Long, // in millis
     val accuracy: Byte, // SensorManager.SENSOR_STATUS_ACCURACY_HIGH

--- a/app/src/main/java/illyan/jay/data/disk/model/RoomSensorEvent.kt
+++ b/app/src/main/java/illyan/jay/data/disk/model/RoomSensorEvent.kt
@@ -21,8 +21,6 @@ package illyan.jay.data.disk.model
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
-import androidx.room.PrimaryKey
-import java.util.UUID
 
 @Entity(
     tableName = "sensor_events",
@@ -33,16 +31,15 @@ import java.util.UUID
             childColumns = ["sessionUUID"]
         )
     ],
-    indices = [Index(value = ["sessionUUID"]), Index(value = ["time"])]
+    indices = [Index(value = ["sessionUUID"]), Index(value = ["time"])],
+    primaryKeys = ["sessionUUID", "time", "type"]
 )
 data class RoomSensorEvent(
-    @PrimaryKey
-    val uuid: String = UUID.randomUUID().toString(),
     val sessionUUID: String,
     val time: Long, // in millis
+    val type: Byte, // Sensor.TYPE_ACCELEROMETER
     val accuracy: Byte, // SensorManager.SENSOR_STATUS_ACCURACY_HIGH
     val x: Float,
     val y: Float,
     val z: Float,
-    val type: Byte // Sensor.TYPE_ACCELEROMETER
 )

--- a/app/src/main/java/illyan/jay/data/disk/model/RoomSession.kt
+++ b/app/src/main/java/illyan/jay/data/disk/model/RoomSession.kt
@@ -39,6 +39,6 @@ data class RoomSession(
     var startLocationName: String? = null,
     var endLocationName: String? = null,
     val distance: Float? = null,
-    val ownerUserUUID: String? = null,
+    val ownerUUID: String? = null,
     val clientUUID: String? = null,
 )

--- a/app/src/main/java/illyan/jay/data/disk/model/RoomSession.kt
+++ b/app/src/main/java/illyan/jay/data/disk/model/RoomSession.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -41,5 +41,4 @@ data class RoomSession(
     val distance: Float? = null,
     val ownerUserUUID: String? = null,
     val clientUUID: String? = null,
-    val isSynced: Boolean = false
 )

--- a/app/src/main/java/illyan/jay/data/network/Mapping.kt
+++ b/app/src/main/java/illyan/jay/data/network/Mapping.kt
@@ -160,7 +160,7 @@ fun Map<String, Any?>.toDomainSession(
         endLocationName = this["endLocationName"] as String?,
         distance = (this["distance"] as Double?)?.toFloat(),
         clientUUID = (this["clientUUID"] as String?),
-        ownerUserUUID = userUUID,
+        ownerUUID = userUUID,
     )
 }
 

--- a/app/src/main/java/illyan/jay/data/network/Mapping.kt
+++ b/app/src/main/java/illyan/jay/data/network/Mapping.kt
@@ -46,7 +46,8 @@ fun DomainSession.toHashMap() = hashMapOf(
 )
 
 fun List<DomainLocation>.toPath(
-    sessionUUID: String
+    sessionUUID: String,
+    ownerUUID: String
 ): PathDocument {
     val accuracyChangeTimestamps = mutableListOf<Timestamp>()
     val accuracyChanges = mutableListOf<Byte>()
@@ -100,6 +101,8 @@ fun List<DomainLocation>.toPath(
 
     return PathDocument(
         uuid = UUID.randomUUID().toString(),
+        sessionUUID = sessionUUID,
+        ownerUUID = ownerUUID,
         accuracyChangeTimestamps = accuracyChangeTimestamps,
         accuracyChanges = accuracyChanges,
         altitudes = altitudes,
@@ -107,7 +110,6 @@ fun List<DomainLocation>.toPath(
         bearingAccuracyChanges = bearingAccuracyChanges,
         bearings = bearings,
         coords = coords,
-        sessionUUID = sessionUUID,
         speeds = speeds,
         speedAccuracyChangeTimestamps = speedAccuracyChangeTimestamps,
         speedAccuracyChanges = speedAccuracyChanges,
@@ -120,18 +122,21 @@ fun List<DomainLocation>.toPath(
 // TODO: Limit size to 1MiB per hashMap
 fun List<DomainLocation>.toPaths(
     sessionUUID: String,
+    ownerUUID: String,
     thresholdInMinutes: Int = 30
 ): List<PathDocument> {
     if (isEmpty()) return emptyList()
     val startMilli = minOf { it.zonedDateTime.toInstant().toEpochMilli() }
     val groupedByTime = groupBy {(it.zonedDateTime.toInstant().toEpochMilli() - startMilli) / thresholdInMinutes.minutes.inWholeMilliseconds }
     return groupedByTime.map {
-        it.value.toPath(sessionUUID)
+        it.value.toPath(sessionUUID, ownerUUID)
     }
 }
 
 fun PathDocument.toHashMap() = hashMapOf(
     "uuid" to uuid,
+    "sessionUUID" to sessionUUID,
+    "ownerUUID" to ownerUUID,
     "accuracyChangeTimestamps" to accuracyChangeTimestamps,
     "accuracyChanges" to accuracyChanges.map { it.toInt() },
     "altitudes" to altitudes.map { it.toInt() },
@@ -139,7 +144,6 @@ fun PathDocument.toHashMap() = hashMapOf(
     "bearingAccuracyChanges" to bearingAccuracyChanges.map { it.toInt() },
     "bearings" to bearings.map { it.toInt() },
     "coords" to coords,
-    "sessionUUID" to sessionUUID,
     "speeds" to speeds,
     "speedAccuracyChangeTimestamps" to speedAccuracyChangeTimestamps,
     "speedAccuracyChanges" to speedAccuracyChanges,

--- a/app/src/main/java/illyan/jay/data/network/Mapping.kt
+++ b/app/src/main/java/illyan/jay/data/network/Mapping.kt
@@ -48,7 +48,6 @@ fun DomainSession.toHashMap() = hashMapOf(
 fun List<DomainLocation>.toPaths(
     sessionUUID: String
 ): List<PathDocument> {
-    val uuids = mutableListOf<String>()
     val accuracyChangeTimestamps = mutableListOf<Timestamp>()
     val accuracyChanges = mutableListOf<Byte>()
     val altitudes = mutableListOf<Short>()
@@ -68,7 +67,6 @@ fun List<DomainLocation>.toPaths(
     sortedLocations.forEach {
         val timestamp = it.zonedDateTime.toTimestamp()
 
-        uuids.add(it.uuid)
         altitudes.add(it.altitude)
         bearings.add(it.bearing)
         coords.add(it.latLng.toGeoPoint())
@@ -103,28 +101,26 @@ fun List<DomainLocation>.toPaths(
     return listOf(
         PathDocument(
             uuid = UUID.randomUUID().toString(),
-            uuids = uuids.toList(),
-            accuracyChangeTimestamps = accuracyChangeTimestamps.toList(),
-            accuracyChanges = accuracyChanges.toList(),
-            altitudes = altitudes.toList(),
-            bearingAccuracyChangeTimestamps = bearingAccuracyChangeTimestamps.toList(),
-            bearingAccuracyChanges = bearingAccuracyChanges.toList(),
-            bearings = bearings.toList(),
-            coords = coords.toList(),
+            accuracyChangeTimestamps = accuracyChangeTimestamps,
+            accuracyChanges = accuracyChanges,
+            altitudes = altitudes,
+            bearingAccuracyChangeTimestamps = bearingAccuracyChangeTimestamps,
+            bearingAccuracyChanges = bearingAccuracyChanges,
+            bearings = bearings,
+            coords = coords,
             sessionUUID = sessionUUID,
-            speeds = speeds.toList(),
-            speedAccuracyChangeTimestamps = speedAccuracyChangeTimestamps.toList(),
-            speedAccuracyChanges = speedAccuracyChanges.toList(),
-            timestamps = timestamps.toList(),
-            verticalAccuracyChangeTimestamps = verticalAccuracyChangeTimestamps.toList(),
-            verticalAccuracyChanges = verticalAccuracyChanges.toList(),
+            speeds = speeds,
+            speedAccuracyChangeTimestamps = speedAccuracyChangeTimestamps,
+            speedAccuracyChanges = speedAccuracyChanges,
+            timestamps = timestamps,
+            verticalAccuracyChangeTimestamps = verticalAccuracyChangeTimestamps,
+            verticalAccuracyChanges = verticalAccuracyChanges,
         )
     )
 }
 
 fun PathDocument.toHashMap() = hashMapOf(
     "uuid" to uuid,
-    "uuids" to uuids,
     "accuracyChangeTimestamps" to accuracyChangeTimestamps,
     "accuracyChanges" to accuracyChanges.map { it.toInt() },
     "altitudes" to altitudes.map { it.toInt() },
@@ -168,7 +164,6 @@ fun List<DocumentSnapshot>.toDomainLocations(): List<DomainLocation> {
     val domainLocations = mutableListOf<DomainLocation>()
 
     forEach { document ->
-        val uuid = document.getString("uuid") ?: ""
         val accuracyChangeTimestamps = document.get("accuracyChangeTimestamps") as List<Timestamp>
         val accuracyChanges = document.get("accuracyChanges") as List<Int>
         val altitudes = document.get("altitudes") as List<Int>
@@ -199,8 +194,7 @@ fun List<DocumentSnapshot>.toDomainLocations(): List<DomainLocation> {
             }.coerceAtLeast(0)
 
             domainLocations.add(
-                DomainLocation( // FIXME: save speed accuracy next time?
-                    uuid = uuid,
+                DomainLocation(
                     sessionUUID = sessionUUID,
                     zonedDateTime = timestamp.toZonedDateTime(),
                     latitude = coords[index].latitude.toFloat(),

--- a/app/src/main/java/illyan/jay/data/network/datasource/FirestoreModule.kt
+++ b/app/src/main/java/illyan/jay/data/network/datasource/FirestoreModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -18,6 +18,8 @@
 
 package illyan.jay.data.network.datasource
 
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreSettings
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import dagger.Module
@@ -32,5 +34,11 @@ object FirestoreModule {
 
     @Singleton
     @Provides
-    fun provideFirestore() = Firebase.firestore
+    fun provideFirestore(): FirebaseFirestore {
+        Firebase.firestore.firestoreSettings = FirebaseFirestoreSettings.Builder()
+            .setCacheSizeBytes(FirebaseFirestoreSettings.CACHE_SIZE_UNLIMITED)
+            .setPersistenceEnabled(true)
+            .build()
+        return Firebase.firestore
+    }
 }

--- a/app/src/main/java/illyan/jay/data/network/model/GeoPointParceler.kt
+++ b/app/src/main/java/illyan/jay/data/network/model/GeoPointParceler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -16,29 +16,17 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package illyan.jay.domain.model
+package illyan.jay.data.network.model
 
-import java.time.ZonedDateTime
+import android.os.Parcel
+import com.google.firebase.firestore.GeoPoint
+import kotlinx.parcelize.Parceler
 
-/**
- * Domain acceleration used for general data handling
- * between DataSources, Interactors and Presenters.
- *
- * @property id
- * @property sessionUUID
- * @property zonedDateTime
- * @property accuracy
- * @property x
- * @property y
- * @property z
- * @constructor Create empty Domain acceleration
- */
-data class DomainSensorEvent(
-    val sessionUUID: String,
-    val zonedDateTime: ZonedDateTime,
-    val type: Byte,
-    val accuracy: Byte, // enum
-    val x: Float,
-    val y: Float,
-    val z: Float,
-)
+object GeoPointParceler : Parceler<GeoPoint> {
+    override fun create(parcel: Parcel) = GeoPoint(parcel.readDouble(), parcel.readDouble())
+
+    override fun GeoPoint.write(parcel: Parcel, flags: Int) {
+        parcel.writeDouble(latitude)
+        parcel.writeDouble(longitude)
+    }
+}

--- a/app/src/main/java/illyan/jay/data/network/model/PathDocument.kt
+++ b/app/src/main/java/illyan/jay/data/network/model/PathDocument.kt
@@ -18,12 +18,16 @@
 
 package illyan.jay.data.network.model
 
+import android.os.Parcelable
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.GeoPoint
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 
+@Parcelize
+@TypeParceler<GeoPoint, GeoPointParceler>
 data class PathDocument(
     var uuid: String,
-    var uuids: List<String>,
     val accuracyChangeTimestamps: List<Timestamp>,
     val accuracyChanges: List<Byte>,
     val altitudes: List<Short>,
@@ -38,4 +42,6 @@ data class PathDocument(
     val timestamps: List<Timestamp>,
     val verticalAccuracyChangeTimestamps: List<Timestamp>,
     val verticalAccuracyChanges: List<Short>
-)
+) : Parcelable
+
+

--- a/app/src/main/java/illyan/jay/data/network/model/PathDocument.kt
+++ b/app/src/main/java/illyan/jay/data/network/model/PathDocument.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -20,10 +20,10 @@ package illyan.jay.data.network.model
 
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.GeoPoint
-import java.util.UUID
 
 data class PathDocument(
-    var uuid: String = UUID.randomUUID().toString(),
+    var uuid: String,
+    var uuids: List<String>,
     val accuracyChangeTimestamps: List<Timestamp>,
     val accuracyChanges: List<Byte>,
     val altitudes: List<Short>,

--- a/app/src/main/java/illyan/jay/data/network/model/PathDocument.kt
+++ b/app/src/main/java/illyan/jay/data/network/model/PathDocument.kt
@@ -28,6 +28,8 @@ import kotlinx.parcelize.TypeParceler
 @TypeParceler<GeoPoint, GeoPointParceler>
 data class PathDocument(
     var uuid: String,
+    val sessionUUID: String, // reference of the session this path is part of
+    val ownerUUID: String,
     val accuracyChangeTimestamps: List<Timestamp>,
     val accuracyChanges: List<Byte>,
     val altitudes: List<Short>,
@@ -35,7 +37,6 @@ data class PathDocument(
     val bearingAccuracyChanges: List<Short>,
     val bearings: List<Short>,
     val coords: List<GeoPoint>,
-    val sessionUUID: String, // reference of the session this path is part of
     val speeds: List<Float>,
     val speedAccuracyChangeTimestamps: List<Timestamp>,
     val speedAccuracyChanges: List<Float>,

--- a/app/src/main/java/illyan/jay/domain/interactor/SessionInteractor.kt
+++ b/app/src/main/java/illyan/jay/domain/interactor/SessionInteractor.kt
@@ -184,6 +184,7 @@ class SessionInteractor @Inject constructor(
                     true
                 }
             }
+            Timber.d("${localOnlySessions.size} sessions are not synced with IDs: ${localOnlySessions.map { it.uuid.take(4) }}")
             locationDiskDataSource.getLocations(localOnlySessions.map { it.uuid }).first { locations ->
                 uploadSessions(
                     localOnlySessions,

--- a/app/src/main/java/illyan/jay/domain/interactor/SessionInteractor.kt
+++ b/app/src/main/java/illyan/jay/domain/interactor/SessionInteractor.kt
@@ -27,7 +27,6 @@ import illyan.jay.data.disk.datasource.SensorEventDiskDataSource
 import illyan.jay.data.disk.datasource.SessionDiskDataSource
 import illyan.jay.data.network.datasource.SessionNetworkDataSource
 import illyan.jay.di.CoroutineScopeIO
-import illyan.jay.di.CoroutineScopeMain
 import illyan.jay.domain.model.DomainLocation
 import illyan.jay.domain.model.DomainSession
 import illyan.jay.util.sphericalPathLength
@@ -64,7 +63,6 @@ class SessionInteractor @Inject constructor(
     private val settingsInteractor: SettingsInteractor,
     private val serviceInteractor: ServiceInteractor,
     @CoroutineScopeIO private val coroutineScopeIO: CoroutineScope,
-    @CoroutineScopeMain private val coroutineScopeMain: CoroutineScope
 ) {
 
     init {
@@ -133,7 +131,7 @@ class SessionInteractor @Inject constructor(
     private var previousUserUUID = authInteractor.userUUID
 
     init {
-        coroutineScopeMain.launch {
+        coroutineScopeIO.launch {
             authInteractor.currentUserStateFlow.collectLatest {
                 _openSnapshotListeners[previousUserUUID]?.remove()
                 _openSnapshotListeners.remove(previousUserUUID)

--- a/app/src/main/java/illyan/jay/domain/model/DomainLocation.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainLocation.kt
@@ -39,7 +39,6 @@ import java.time.ZonedDateTime
  * @constructor Create empty Domain location
  */
 data class DomainLocation(
-    val uuid: String,
     var sessionUUID: String,
     val zonedDateTime: ZonedDateTime,
     val latitude: Float,

--- a/app/src/main/java/illyan/jay/domain/model/DomainLocation.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainLocation.kt
@@ -39,7 +39,7 @@ import java.time.ZonedDateTime
  * @constructor Create empty Domain location
  */
 data class DomainLocation(
-    val id: Long = -1,
+    val uuid: String,
     var sessionUUID: String,
     val zonedDateTime: ZonedDateTime,
     val latitude: Float,

--- a/app/src/main/java/illyan/jay/domain/model/DomainSensorEvent.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainSensorEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -34,7 +34,7 @@ import java.time.ZonedDateTime
  * @constructor Create empty Domain acceleration
  */
 data class DomainSensorEvent(
-    val id: Long = -1,
+    val uuid: String,
     val sessionUUID: String,
     val zonedDateTime: ZonedDateTime,
     val accuracy: Byte, // enum

--- a/app/src/main/java/illyan/jay/domain/model/DomainSession.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainSession.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -43,8 +43,7 @@ data class DomainSession(
     var endLocationName: String? = null,
     var distance: Float? = null,
     var ownerUserUUID: String? = null,
-    var clientUUID: String? = null,
-    val isSynced: Boolean = false
+    var clientUUID: String? = null
 ) {
     val isOwned = ownerUserUUID != null
 

--- a/app/src/main/java/illyan/jay/domain/model/DomainSession.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainSession.kt
@@ -21,15 +21,6 @@ package illyan.jay.domain.model
 import com.google.android.gms.maps.model.LatLng
 import java.time.ZonedDateTime
 
-/**
- * Domain session used for general data handling
- * between DataSources, Interactors and Presenters.
- *
- * @property id
- * @property startDateTime
- * @property endDateTime
- * @constructor Create empty Domain session
- */
 data class DomainSession(
     var uuid: String,
     val startDateTime: ZonedDateTime,
@@ -42,10 +33,10 @@ data class DomainSession(
     var startLocationName: String? = null,
     var endLocationName: String? = null,
     var distance: Float? = null,
-    var ownerUserUUID: String? = null,
+    var ownerUUID: String? = null,
     var clientUUID: String? = null
 ) {
-    val isOwned = ownerUserUUID != null
+    val isOwned get() = ownerUUID != null
 
     var startLocation: LatLng?
         get() {

--- a/app/src/main/java/illyan/jay/ui/home/Home.kt
+++ b/app/src/main/java/illyan/jay/ui/home/Home.kt
@@ -442,7 +442,7 @@ fun HomeScreen(
     val screenHeightDp = LocalConfiguration.current.screenHeightDp.dp
     LaunchedEffect(density) { _density.value = density }
     LaunchedEffect(screenHeightDp) { _screenHeight.value = screenHeightDp }
-    // FIXME: make insets to accomodate for status bar's padding
+    // FIXME: make insets to accommodate for status bar's padding
     ConstraintLayout(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/illyan/jay/ui/home/Home.kt
+++ b/app/src/main/java/illyan/jay/ui/home/Home.kt
@@ -64,7 +64,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -1142,8 +1141,7 @@ private fun SearchNavHost(
             .animateContentSize { _, _ -> }
             .alpha(alpha = searchAlpha)
             .padding(bottom = SearchBarHeight - RoundedCornerRadius)
-            .navigationBarsPadding()
-            .statusBarsPadding(),
+            .navigationBarsPadding(),
     )
 }
 

--- a/app/src/main/java/illyan/jay/ui/home/Home.kt
+++ b/app/src/main/java/illyan/jay/ui/home/Home.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -48,7 +48,6 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -142,7 +141,6 @@ import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.material.placeholder
 import com.google.accompanist.placeholder.material.shimmer
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapView
@@ -424,17 +422,6 @@ fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val systemUiController = rememberSystemUiController()
-    val useDarkIcons = !isSystemInDarkTheme()
-    LaunchedEffect(systemUiController, useDarkIcons) {
-        // Update all of the system bar colors to be transparent
-        // and use dark icons if we're in light theme
-        systemUiController.setSystemBarsColor(
-            color = Color.Transparent,
-            darkIcons = useDarkIcons
-        )
-        // setStatusBarColor() and setNavigationBarColor() also exist
-    }
     LaunchedEffect(Unit) {
         viewModel.stopDanglingOngoingSessions()
     }
@@ -455,8 +442,11 @@ fun HomeScreen(
     val screenHeightDp = LocalConfiguration.current.screenHeightDp.dp
     LaunchedEffect(density) { _density.value = density }
     LaunchedEffect(screenHeightDp) { _screenHeight.value = screenHeightDp }
+    // FIXME: make insets to accomodate for status bar's padding
     ConstraintLayout(
-        modifier = Modifier.onGloballyPositioned { coords ->
+        modifier = Modifier
+            .fillMaxSize()
+            .onGloballyPositioned { coords ->
             var topSet = false
             val absoluteTopPosition = (coords.positionInWindow().y / density).dp
             if (_absoluteTop.value != absoluteTopPosition) {
@@ -516,7 +506,6 @@ fun HomeScreen(
                     start.linkTo(parent.start)
                 }
                 .imePadding()
-                .statusBarsPadding()
                 .navigationBarsPadding(),
             onDrag = {
                 onSearchBarDrag(
@@ -1152,8 +1141,9 @@ private fun SearchNavHost(
             .fillMaxHeight(fraction = searchFraction)
             .animateContentSize { _, _ -> }
             .alpha(alpha = searchAlpha)
+            .padding(bottom = SearchBarHeight - RoundedCornerRadius)
             .navigationBarsPadding()
-            .padding(bottom = SearchBarHeight - RoundedCornerRadius),
+            .statusBarsPadding(),
     )
 }
 

--- a/app/src/main/java/illyan/jay/ui/search/Search.kt
+++ b/app/src/main/java/illyan/jay/ui/search/Search.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -21,10 +21,13 @@ package illyan.jay.ui.search
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -88,6 +91,7 @@ val DividerThickness = 1.dp
 fun SearchScreen(
     viewModel: SearchViewModel = hiltViewModel()
 ) {
+    val statusBarTopPadding = WindowInsets.systemBars.asPaddingValues().calculateTopPadding()
     DisposableEffect(Unit) {
         viewModel.load()
         onDispose { viewModel.dispose() }
@@ -100,7 +104,7 @@ fun SearchScreen(
             .fillMaxSize()
             .padding(horizontal = SearchPadding),
         contentPadding = PaddingValues(
-            top = SearchPadding,
+            top = SearchPadding + statusBarTopPadding,
             bottom = RoundedCornerRadius + SearchPadding
         )
     ) {

--- a/app/src/main/java/illyan/jay/ui/session/SessionViewModel.kt
+++ b/app/src/main/java/illyan/jay/ui/session/SessionViewModel.kt
@@ -65,7 +65,6 @@ class SessionViewModel @Inject constructor(
                     }
                 }
             }
-
         }
     }
 }

--- a/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
@@ -51,6 +51,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -244,7 +245,8 @@ fun SessionsList(
     LazyColumn(
         modifier = modifier,
         contentPadding = DefaultContentPadding,
-        verticalArrangement = Arrangement.spacedBy(MenuItemPadding)
+        verticalArrangement = Arrangement.spacedBy(MenuItemPadding),
+        reverseLayout = true
     ) {
         if (noSessionsToShow) {
             item {
@@ -295,6 +297,11 @@ fun SessionsList(
         }
         items(allSessionUUIDs) {
             val session by viewModel.getSessionStateFlow(it).collectAsState()
+            DisposableEffect(true) {
+                onDispose {
+                    viewModel.disposeSessionStateFlow(it)
+                }
+            }
             val isPlaceholderVisible = session == null
             SessionCard(
                 modifier = Modifier
@@ -377,7 +384,7 @@ fun SessionCard(
                     }
                 }
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
                     AnimatedVisibility(visible = session?.isLocal == true) {
                         Icon(imageVector = Icons.Rounded.Save, contentDescription = "")

--- a/app/src/main/java/illyan/jay/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/SessionsViewModel.kt
@@ -260,8 +260,13 @@ class SessionsViewModel @Inject constructor(
                         sessionInteractor.refreshSessionEndLocation(session)
                     }
                     locationInteractor.getLocations(sessionUUID).first { locations ->
+                        val totalDistance = if (locations.isNotEmpty()) {
+                            locations.sphericalPathLength()
+                        } else {
+                            session.distance?.toDouble() ?: 0.0
+                        }
                         sessionMutableStateFlow.value = session.toUiModel(
-                            totalDistance = locations.sphericalPathLength(),
+                            totalDistance = totalDistance,
                             currentClientUUID = clientUUID.value,
                             isLocal = locations.isNotEmpty(),
                             isSynced = syncedSessions.value.any { it.uuid == sessionUUID }

--- a/app/src/main/java/illyan/jay/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/SessionsViewModel.kt
@@ -133,7 +133,9 @@ class SessionsViewModel @Inject constructor(
         sessions.addAll(ownedLocal)
         sessions.addAll(notOwnedLocal)
         val distinctSessions = sessions.distinct()
-        val sortedSessions = distinctSessions.sortedByDescending { it.second.toEpochSecond() }
+        val sortedSessions = distinctSessions
+            .sortedByDescending { it.second.toEpochSecond() }
+            .map { it.first }
         sortedSessions.intersect(sessionStateFlows.keys).forEach { uuid ->
             val sessionFlow = sessionStateFlows[uuid]!!
             val isSynced = synced.any { it.uuid == uuid }
@@ -141,7 +143,7 @@ class SessionsViewModel @Inject constructor(
                 sessionFlow.value = sessionFlow.value?.copy(isSynced = isSynced)
             }
         }
-        sortedSessions.map { it.first }
+        sortedSessions
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     val canSyncSessions = combine(

--- a/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
@@ -38,8 +38,11 @@ data class UiSession(
     val duration: Duration,
     val isLocal: Boolean,
     val isSynced: Boolean,
-    val isNotOwned: Boolean
-)
+    val clientUUID: String?
+) {
+    val isOwned get() = !clientUUID.isNullOrBlank()
+    val isNotOwned get() = !isOwned
+}
 
 fun DomainSession.toUiModel(
     locations: List<DomainLocation>,
@@ -82,6 +85,6 @@ fun DomainSession.toUiModel(
         },
         isSynced = isSynced,
         isLocal = isLocal,
-        isNotOwned = ownerUserUUID == null
+        clientUUID = clientUUID
     )
 }

--- a/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
@@ -38,9 +38,10 @@ data class UiSession(
     val duration: Duration,
     val isLocal: Boolean,
     val isSynced: Boolean,
-    val clientUUID: String?
+    val clientUUID: String?,
+    val ownerUUID: String?
 ) {
-    val isOwned get() = !clientUUID.isNullOrBlank()
+    val isOwned get() = !ownerUUID.isNullOrBlank()
     val isNotOwned get() = !isOwned
 }
 
@@ -85,6 +86,7 @@ fun DomainSession.toUiModel(
         },
         isSynced = isSynced,
         isLocal = isLocal,
-        clientUUID = clientUUID
+        clientUUID = clientUUID,
+        ownerUUID = ownerUUID
     )
 }

--- a/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -46,12 +46,14 @@ fun DomainSession.toUiModel(
     currentClientUUID: String,
     isLocal: Boolean = clientUUID == currentClientUUID,
     currentTime: ZonedDateTime = ZonedDateTime.now(),
+    isSynced: Boolean = false,
 ): UiSession {
     return toUiModel(
         locations.sphericalPathLength(),
         currentClientUUID,
         isLocal,
-        currentTime
+        currentTime,
+        isSynced
     )
 }
 
@@ -60,6 +62,7 @@ fun DomainSession.toUiModel(
     currentClientUUID: String,
     isLocal: Boolean = clientUUID == currentClientUUID,
     currentTime: ZonedDateTime = ZonedDateTime.now(),
+    isSynced: Boolean = false,
 ): UiSession {
     return UiSession(
         uuid = uuid,

--- a/app/src/main/java/illyan/jay/ui/theme/Theme.kt
+++ b/app/src/main/java/illyan/jay/ui/theme/Theme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -28,10 +28,11 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 private val DarkColorScheme = darkColorScheme(
     primary = TealGreen,
@@ -56,6 +57,8 @@ fun JayTheme(
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
+    val systemUiController = rememberSystemUiController()
+    val useDarkIcons = isSystemInDarkTheme()
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
@@ -68,9 +71,15 @@ fun JayTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
             WindowCompat.setDecorFitsSystemWindows(window, false)
+
+            // Update all of the system bar colors to be transparent
+            // and use dark icons if we're in light theme
+            systemUiController.setSystemBarsColor(
+                color = Color.Transparent,
+                darkIcons = useDarkIcons
+            )
         }
     }
 

--- a/app/src/main/java/illyan/jay/ui/theme/Theme.kt
+++ b/app/src/main/java/illyan/jay/ui/theme/Theme.kt
@@ -58,7 +58,7 @@ fun JayTheme(
     content: @Composable () -> Unit
 ) {
     val systemUiController = rememberSystemUiController()
-    val useDarkIcons = isSystemInDarkTheme()
+    val useDarkIcons = !isSystemInDarkTheme()
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current

--- a/app/src/main/java/illyan/jay/util/Util.kt
+++ b/app/src/main/java/illyan/jay/util/Util.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balázs Püspök-Kiss (Illyan)
+ * Copyright (c) 2022-2023 Balázs Püspök-Kiss (Illyan)
  *
  * Jay is a driver behaviour analytics app.
  *
@@ -141,11 +141,13 @@ fun LatLng.equals(latLng: LatLng, accuracyInMeters: Double): Boolean {
     return SphericalUtil.computeDistanceBetween(this, latLng) <= accuracyInMeters
 }
 
+fun LatLng.toGeoPoint() = GeoPoint(latitude, longitude)
+
+fun GeoPoint.toLatLng() = LatLng(latitude, longitude)
+
 fun Instant.toTimestamp() = Timestamp(epochSecond, nano)
 
 fun ZonedDateTime.toTimestamp() = toInstant().toTimestamp()
-
-fun LatLng.toGeoPoint() = GeoPoint(latitude, longitude)
 
 fun Timestamp.toInstant(): Instant = Instant.ofEpochSecond(seconds, nanoseconds.toLong())
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '7.4.0' apply false
+    id 'com.android.library' version '7.4.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
     id 'androidx.navigation.safeargs.kotlin' version '2.5.1' apply false
     id 'org.sonarqube' version "3.4.0.2513"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,7 +16,7 @@
 # If not, see <https://www.gnu.org/licenses/>.
 #
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-rc-1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Restructured some data classes to require less storage space.
- Making use of cache when using Firestore.
- Fixed a lot of bugs when recording sessions offline.
- Denormalized some cloud data classes, so some queries takes less listeners.
- Long sessions' paths now get uploaded in chunks instead of whole, due to them being very large (more than 1MiB, which is the limit for Firestore for the size of a document).

Closes #37