### PR TITLE
53 add individual actions on a session in sessions screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.0'
     implementation "androidx.core:core-ktx:1.9.0"
     implementation "androidx.collection:collection-ktx:1.2.0" // The Collection extensions contain utility functions for working with Android's memory-efficient collection libraries, including ArrayMap, LongSparseArray, LruCache, and others.
-    implementation "androidx.appcompat:appcompat:1.6.0"
+    implementation "androidx.appcompat:appcompat:1.6.1"
     implementation 'androidx.activity:activity-ktx:1.6.1'
     implementation "com.google.android.material:material:1.8.0"
 
@@ -114,7 +114,7 @@ dependencies {
     def lifecycle_version = '2.6.0-alpha05'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
-    implementation 'androidx.compose.material3:material3:1.1.0-alpha05'
+    implementation 'androidx.compose.material3:material3:1.1.0-alpha06'
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.compose.ui:ui-util:$compose_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version"
@@ -139,6 +139,9 @@ dependencies {
 
     // Layouts
     implementation "androidx.constraintlayout:constraintlayout-compose:1.0.1"
+
+    // Item Swipe
+    implementation "me.saket.swipe:swipe:1.0.0"
 
     // Mapbox
     implementation "com.mapbox.maps:android:10.11.0-beta.1"

--- a/app/src/main/java/illyan/jay/data/disk/dao/SessionDao.kt
+++ b/app/src/main/java/illyan/jay/data/disk/dao/SessionDao.kt
@@ -75,6 +75,10 @@ interface SessionDao {
     fun getSessions(ownerUUID: String? = null): Flow<List<RoomSession>>
 
     @Transaction
+    @Query("SELECT * FROM session WHERE uuid IN (:sessionUUIDs)")
+    fun getSessions(sessionUUIDs: List<String>): Flow<List<RoomSession>>
+
+    @Transaction
     @Query("SELECT uuid FROM session WHERE ownerUUID IS :ownerUUID OR ownerUUID IS NULL")
     fun getSessionUUIDs(ownerUUID: String? = null): Flow<List<String>>
 

--- a/app/src/main/java/illyan/jay/data/disk/datasource/SessionDiskDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/disk/datasource/SessionDiskDataSource.kt
@@ -29,7 +29,7 @@ import timber.log.Timber
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
-import java.util.*
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -51,6 +51,9 @@ class SessionDiskDataSource @Inject constructor(
     fun getSessions(ownerUUID: String?) =
         sessionDao.getSessions(ownerUUID).map { it.map(RoomSession::toDomainModel) }
 
+    fun getSessions(sessionUUIDs: List<String>) = sessionDao.getSessions(sessionUUIDs)
+        .map { it.map(RoomSession::toDomainModel) }
+
     fun getSessionUUIDs(ownerUUID: String?) = sessionDao.getSessionUUIDs(ownerUUID)
 
     fun getAllNotOwnedSessions() = sessionDao.getAllNotOwnedSessions()
@@ -63,7 +66,6 @@ class SessionDiskDataSource @Inject constructor(
         Timber.i("$ownerUUID owns all sessions without an owner")
         sessionDao.ownAllNotOwnedSessions(ownerUUID)
     }
-
 
     fun ownNotOwnedSession(sessionUUID: String, ownerUUID: String) {
         Timber.i("$ownerUUID owns session with no owner yet: $sessionUUID")

--- a/app/src/main/java/illyan/jay/data/network/datasource/LocationNetworkDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/network/datasource/LocationNetworkDataSource.kt
@@ -18,10 +18,22 @@
 
 package illyan.jay.data.network.datasource
 
+import android.os.Parcel
+import android.os.Parcelable
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.maps.android.ktx.utils.sphericalPathLength
+import illyan.jay.data.network.model.PathDocument
 import illyan.jay.data.network.toDomainLocations
+import illyan.jay.data.network.toHashMap
+import illyan.jay.data.network.toPaths
+import illyan.jay.di.CoroutineScopeIO
 import illyan.jay.domain.interactor.AuthInteractor
 import illyan.jay.domain.model.DomainLocation
+import illyan.jay.domain.model.DomainSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -29,7 +41,8 @@ import javax.inject.Singleton
 @Singleton
 class LocationNetworkDataSource @Inject constructor(
     private val firestore: FirebaseFirestore,
-    private val authInteractor: AuthInteractor
+    private val authInteractor: AuthInteractor,
+    @CoroutineScopeIO private val coroutineScopeIO: CoroutineScope
 ) {
     fun getLocations(
         sessionUUID: String,
@@ -52,5 +65,133 @@ class LocationNetworkDataSource @Inject constructor(
         } else {
             listener(emptyList())
         }
+    }
+
+    fun insertLocations(
+        domainSessions: List<DomainSession>,
+        domainLocations: List<DomainLocation>,
+    ) {
+        val paths = mutableListOf<PathDocument>()
+        domainSessions.forEach { session ->
+            val locationsForThisSession = domainLocations.filter { it.sessionUUID.contentEquals(session.uuid) }
+            if (session.distance == null) {
+                session.distance = locationsForThisSession
+                    .sortedBy { it.zonedDateTime.toInstant().toEpochMilli() }
+                    .map { it.latLng }.sphericalPathLength().toFloat()
+            }
+            paths.addAll(locationsForThisSession.toPaths(session.uuid, session.ownerUUID!!))
+        }
+    }
+
+    fun insertPath(
+        path: PathDocument,
+        onSuccess: () -> Unit = { Timber.d("Successfully inserted path ${path.uuid.take(4)}") }
+    ) = insertPaths(
+        paths = listOf(path),
+        onSuccess = onSuccess
+    )
+
+    fun insertPaths(
+        paths: List<PathDocument>,
+        onSuccess: () -> Unit = { Timber.d("Successfully inserted ${paths.size} paths") },
+    ) {
+        if (!authInteractor.isUserSignedIn || paths.isEmpty()) return
+        val pathRefs = paths.map {
+            firestore
+                .collection(SessionNetworkDataSource.PathsCollectionPath)
+                .document(it.uuid) to it
+        }
+        firestore.runBatch { batch ->
+            pathRefs.forEach {
+                val parcel = Parcel.obtain()
+                it.second.writeToParcel(parcel, Parcelable.PARCELABLE_WRITE_RETURN_VALUE)
+                val dataSizeInBytes = parcel.dataSize()
+                Timber.i("Path ${it.second.uuid.take(4)} for session ${it.second.sessionUUID.take(4)} size is around $dataSizeInBytes bytes")
+                // TODO: make size calculations more reliable and easier to implement
+                val maxSizeInBytes = 1_048_576
+                if (dataSizeInBytes < maxSizeInBytes) {
+                    batch.set(it.first, it.second.toHashMap())
+                } else {
+                    Timber.d("Not uploading this path, as $dataSizeInBytes bytes exceeds the $maxSizeInBytes byte limit")
+                }
+                parcel.recycle()
+            }
+        }.addOnSuccessListener {
+            onSuccess()
+        }.addOnFailureListener { exception ->
+            Timber.e(exception, "Error: ${exception.message}")
+        }.addOnCanceledListener {
+            Timber.i("Operation canceled")
+        }
+    }
+
+    fun deleteLocationsForUser() {
+        if (!authInteractor.isUserSignedIn) return
+        val arePathsDeleted = MutableStateFlow(false)
+        val pathSnapshotListener = firestore
+            .collection(SessionNetworkDataSource.PathsCollectionPath)
+            .whereEqualTo("ownerUUID", authInteractor.userUUID)
+            .addSnapshotListener { pathSnapshot, pathError ->
+                if (pathError != null) {
+                    Timber.e(pathError, "Error while deleting user data: ${pathError.message}")
+                } else if (!arePathsDeleted.value) {
+                    Timber.d("Delete ${pathSnapshot!!.documents.size} path data for user ${authInteractor.userUUID?.take(4)}")
+                    pathSnapshot.documents.forEach {
+                        it.reference.delete()
+                    }
+                    arePathsDeleted.value = true
+                }
+            }
+        coroutineScopeIO.launch {
+            arePathsDeleted.first {
+                if (it) {
+                    Timber.d("Removing path listener from Firestore")
+                    pathSnapshotListener.remove()
+                }
+                it
+            }
+        }
+    }
+
+    fun deleteLocationsForSession(
+        sessionUUID: String,
+        onDelete: () -> Unit = {}
+    ) {
+        val arePathsDeleted = MutableStateFlow(false)
+        val pathSnapshotListener = firestore
+            .collection(SessionNetworkDataSource.PathsCollectionPath)
+            .whereEqualTo("sessionUUID", sessionUUID)
+            .addSnapshotListener { pathSnapshot, pathError ->
+                if (pathError != null) {
+                    Timber.e(pathError, "Error while deleting path data: ${pathError.message}")
+                } else {
+                    Timber.d("Delete ${pathSnapshot!!.documents.size} path data for user ${authInteractor.userUUID?.take(4)}")
+                    pathSnapshot.documents.forEach {
+                        it.reference.delete()
+                    }
+                    arePathsDeleted.value = true
+                    onDelete()
+                }
+            }
+        coroutineScopeIO.launch {
+            arePathsDeleted.first { arePathsDeleted ->
+                if (arePathsDeleted) {
+                    Timber.d("Removing path listener from Firestore")
+                    pathSnapshotListener.remove()
+                }
+                arePathsDeleted
+            }
+        }
+    }
+
+    fun deleteLocationsForSessions(
+        sessionUUIDs: List<String>,
+        onDelete: (String) -> Unit = {}
+    ) {
+        if (sessionUUIDs.isEmpty()) {
+            Timber.d("No sessions given to delete paths for!")
+            return
+        }
+        sessionUUIDs.forEach { deleteLocationsForSession(it) { onDelete(it) } }
     }
 }

--- a/app/src/main/java/illyan/jay/data/network/datasource/SessionNetworkDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/network/datasource/SessionNetworkDataSource.kt
@@ -62,7 +62,7 @@ class SessionNetworkDataSource @Inject constructor(
                     listener(null as List<DomainSession>?)
                 } else {
                     val domainSessions = (snapshot?.get(SessionsCollectionPath) as? List<Map<String, Any>>?)?.map {
-                        it.toDomainSession(it["uuid"] as String, authInteractor.userUUID!!)
+                        it.toDomainSession(it["uuid"] as String, userUUID)
                     } ?: emptyList()
                     Timber.d("Firebase got sessions with IDs: ${
                         domainSessions.map { it.uuid.substring(0..3) }

--- a/app/src/main/java/illyan/jay/domain/interactor/LocationInteractor.kt
+++ b/app/src/main/java/illyan/jay/domain/interactor/LocationInteractor.kt
@@ -77,7 +77,7 @@ class LocationInteractor @Inject constructor(
      * @return location data flow for a particular session.
      */
     fun getLocations(sessionUUID: String): Flow<List<DomainLocation>> {
-        Timber.d("Trying to load path for session with ID from disk: $sessionUUID")
+        Timber.d("Trying to load path for session with ID from disk: ${sessionUUID.take(4)}")
         return locationDiskDataSource.getLocations(sessionUUID)
     }
 

--- a/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
@@ -22,6 +22,7 @@ import android.app.Activity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -187,11 +188,7 @@ fun SessionsScreen(
     onSessionSelected: (String) -> Unit = {},
     disposeSessionStateFlow: (String) -> Unit = {},
     getSessionStateFlow: @Composable (String) -> State<UiSession?> = {
-        remember {
-            mutableStateOf(
-                null
-            )
-        }
+        remember { mutableStateOf(null) }
     },
 ) {
     val showButtons = isUserSignedIn &&
@@ -386,6 +383,7 @@ fun SessionInteractionButton(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SessionsList(
     modifier: Modifier = Modifier,
@@ -469,7 +467,7 @@ fun SessionsList(
                     )
                 }
             }
-            items(sessionUUIDs) {
+            items(sessionUUIDs, key = { it }) {
                 val session by getSessionStateFlow(it)
                 DisposableEffect(Unit) {
                     onDispose {
@@ -480,7 +478,8 @@ fun SessionsList(
                 SessionCard(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .cardPlaceholder(isPlaceholderVisible),
+                        .cardPlaceholder(isPlaceholderVisible)
+                        .animateItemPlacement(),
                     session = session,
                     onClick = onSessionSelected,
                     onSync = { syncSession(it) },

--- a/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/Sessions.kt
@@ -69,6 +69,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -581,41 +582,26 @@ fun SessionCard(
     onSync: () -> Unit = {},
     content: @Composable () -> Unit = {},
 ) {
-    val deleteFromCloudAction = SwipeAction(
-        icon = {
-            Icon(
-                modifier = Modifier.padding(horizontal = 32.dp),
-                imageVector = Icons.Rounded.CloudOff,
-                contentDescription = "",
-                tint = MaterialTheme.colorScheme.onSurface
-            )
-        },
-        background = if (session?.isSynced == true) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.surface,
+    val isDeleteFromCloudEnabled = session?.isSynced == true && session.isNotOngoing
+    val deleteFromCloudAction = sessionSwipeAction(
+        icon = Icons.Rounded.CloudOff,
+        enabled = isDeleteFromCloudEnabled,
+        enabledBackgroundColor = MaterialTheme.colorScheme.tertiary,
         onSwipe = onDeleteFromCloud
     )
-    val deleteAction = SwipeAction(
-        icon = {
-            Icon(
-                modifier = Modifier.padding(horizontal = 32.dp),
-                imageVector = Icons.Rounded.Delete,
-                contentDescription = "",
-                tint = MaterialTheme.colorScheme.onSurface
-            )
-        },
-        background = if (session?.canDelete == true) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.surface,
-        onSwipe = onDelete,
+    val isDeleteEnabled = session?.canDelete == true && session.isNotOngoing
+    val deleteAction = sessionSwipeAction(
+        icon = Icons.Rounded.Delete,
+        enabled = isDeleteEnabled,
+        enabledBackgroundColor = MaterialTheme.colorScheme.error,
+        onSwipe = onDelete
     )
-    val syncAction = SwipeAction(
-        icon = {
-            Icon(
-                modifier = Modifier.padding(horizontal = 32.dp),
-                imageVector = Icons.Rounded.SyncAlt,
-                contentDescription = "",
-                tint = MaterialTheme.colorScheme.onSurface
-            )
-        },
-        background = if (session?.isSynced == false) MaterialTheme.signatureBlue else MaterialTheme.colorScheme.surface,
-        onSwipe = if (session?.isSynced == false) onSync else null ?: {}
+    val isSyncEnabled = session?.isSynced == false && session.isNotOngoing
+    val syncAction = sessionSwipeAction(
+        icon = Icons.Rounded.SyncAlt,
+        enabled = isSyncEnabled,
+        enabledBackgroundColor = MaterialTheme.signatureBlue,
+        onSwipe = onSync
     )
     val containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp)
     val cardColors = CardDefaults.cardColors(
@@ -652,52 +638,6 @@ fun SessionCard(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
                     ) {
-//                        LazyRow(
-//                            modifier = Modifier
-//                                .weight(1f)
-//                                .padding(horizontal = 8.dp),
-//                            verticalAlignment = Alignment.CenterVertically,
-//                            horizontalArrangement = Arrangement.spacedBy(6.dp)
-//                        ) {
-//                            item {
-//                                Crossfade(
-//                                    modifier = Modifier.animateContentSize(),
-//                                    targetState = session?.startLocationName
-//                                ) {
-//                                    Text(
-//                                        text = it ?: stringResource(R.string.unknown),
-//                                        style = MaterialTheme.typography.titleLarge,
-//                                        color = MaterialTheme.colorScheme.onSurface,
-//                                    )
-//                                }
-//                            }
-//                            item {
-//                                Icon(
-//                                    imageVector = Icons.Rounded.ArrowRightAlt, contentDescription = "",
-//                                    tint = MaterialTheme.colorScheme.onSurface,
-//                                )
-//                            }
-//                            item {
-//                                Crossfade(
-//                                    modifier = Modifier.animateContentSize(),
-//                                    targetState = (session?.endDateTime == null) to session?.endLocationName
-//                                ) {
-//                                    if (it.first) {
-//                                        Icon(
-//                                            imageVector = Icons.Rounded.MoreHoriz,
-//                                            contentDescription = "",
-//                                            tint = MaterialTheme.colorScheme.onSurface,
-//                                        )
-//                                    } else {
-//                                        Text(
-//                                            text = it.second ?: stringResource(R.string.unknown),
-//                                            style = MaterialTheme.typography.titleLarge,
-//                                            color = MaterialTheme.colorScheme.onSurface,
-//                                        )
-//                                    }
-//                                }
-//                            }
-//                        }
                         Row(
                             modifier = Modifier
                                 .weight(1f)
@@ -789,6 +729,30 @@ fun SessionCard(
             }
         }
     }
+}
+
+@Composable
+fun sessionSwipeAction(
+    modifier: Modifier = Modifier,
+    icon: ImageVector,
+    tint: Color = MaterialTheme.colorScheme.onSurface,
+    enabled: Boolean = true,
+    onSwipe: () -> Unit = {},
+    enabledBackgroundColor: Color = Color.Transparent,
+    disabledBackgroundColor: Color = MaterialTheme.colorScheme.surface
+): SwipeAction {
+    return SwipeAction(
+        icon = {
+            Icon(
+                modifier = modifier.padding(horizontal = 32.dp),
+                imageVector = icon,
+                contentDescription = "",
+                tint = tint
+            )
+        },
+        background = if (enabled) enabledBackgroundColor else disabledBackgroundColor,
+        onSwipe = if (enabled) onSwipe else {{}},
+    )
 }
 
 @Composable

--- a/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
@@ -44,6 +44,8 @@ data class UiSession(
     val isOwned get() = !ownerUUID.isNullOrBlank()
     val isNotOwned get() = !isOwned
     val canDelete get() = isLocal || isSynced
+    val isOngoing get() = endDateTime == null
+    val isNotOngoing get() = !isOngoing
 }
 
 fun DomainSession.toUiModel(

--- a/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
+++ b/app/src/main/java/illyan/jay/ui/sessions/model/UiSession.kt
@@ -43,6 +43,7 @@ data class UiSession(
 ) {
     val isOwned get() = !ownerUUID.isNullOrBlank()
     val isNotOwned get() = !isOwned
+    val canDelete get() = isLocal || isSynced
 }
 
 fun DomainSession.toUiModel(

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@
 
 buildscript {
     ext {
-        compose_version = '1.4.0-alpha05'
+        compose_version = '1.4.0-beta01'
     }
     dependencies {
         classpath 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1'
@@ -27,7 +27,7 @@ buildscript {
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.44.2'
         classpath 'de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0'
         classpath 'org.jetbrains.kotlin:kotlin-serialization:1.8.0'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'
     }
 }
 


### PR DESCRIPTION
Added `SwipeActions` on each `Session` on `SessionsScreen`. User is able to sync and delete sessions individually. Restructured some parts of querying to `Firebase Firestore`.

closes #53