### PR TITLE
56 use firestore model objects

### DIFF
--- a/app/src/main/java/illyan/jay/data/network/datasource/UserNetworkDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/network/datasource/UserNetworkDataSource.kt
@@ -94,7 +94,7 @@ class UserNetworkDataSource @Inject constructor(
                     _user.value = FirestoreUserWithUUID(userUUID, user)
                     onSuccess(user)
                 }
-                _isLoading.value = false
+                if (_isLoading.value) _isLoading.value = false
             }
         }
         _userListenerRegistration.value?.remove()


### PR DESCRIPTION
Added `Firestore` model classes and removed raw strings from queries to `Firebase Firestore`. Relying on `toObject` method to parse data instead of `maps`. Reworked a lot of underlying structures of networking via `Firestore SDK`.