### PR TITLE
Reduce Path data sizes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,6 @@ android {
         applicationId "illyan.jay"
         minSdk 21
         targetSdk 33
-        compileSdkPreview "UpsideDownCake"
         versionCode 3
         versionName "0.2.0-alpha"
 
@@ -114,6 +113,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.6.1"
     implementation 'androidx.activity:activity-ktx:1.6.1'
     implementation "com.google.android.material:material:1.8.0"
+    implementation fileTree(dir: 'libs', include: ['*.aar', '*.jar'], exclude: [])
 
     // Compose
     def activity_version = '1.7.0-beta02'
@@ -197,10 +197,17 @@ dependencies {
     testImplementation "androidx.room:room-testing:$room_version" // optional - Test helpers
     implementation "androidx.room:room-paging:$room_version" // optional - Paging 3 Integration
 
-    // Proto DataStore
+    // Serialization
     implementation "androidx.datastore:datastore:1.0.0"
     implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-protobuf:1.5.0'
+
+    // Compression
+    def brotliVersion = "1.11.0"
+    implementation 'com.github.luben:zstd-jni:1.5.4-1@aar'
+//    implementation "com.aayushatharva.brotli4j:brotli4j:$brotliVersion"
+    testImplementation "com.github.luben:zstd-jni:1.5.4-1"
 
     // Coroutine
     def coroutines_version = '1.6.4'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,7 @@ android {
 
 dependencies {
     // Core
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.10'
     implementation "androidx.core:core-ktx:1.9.0"
     implementation "androidx.collection:collection-ktx:1.2.0" // The Collection extensions contain utility functions for working with Android's memory-efficient collection libraries, including ArrayMap, LongSparseArray, LruCache, and others.
     implementation "androidx.appcompat:appcompat:1.6.1"
@@ -204,9 +204,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-protobuf:1.5.0'
 
     // Compression
-    def brotliVersion = "1.11.0"
     implementation 'com.github.luben:zstd-jni:1.5.4-1@aar'
-//    implementation "com.aayushatharva.brotli4j:brotli4j:$brotliVersion"
     testImplementation "com.github.luben:zstd-jni:1.5.4-1"
 
     // Coroutine

--- a/app/src/main/java/illyan/jay/data/network/Mapping.kt
+++ b/app/src/main/java/illyan/jay/data/network/Mapping.kt
@@ -18,19 +18,35 @@
 
 package illyan.jay.data.network
 
+import android.os.Parcel
+import android.os.Parcelable
+import android.util.Base64
+import com.github.luben.zstd.Zstd
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.GeoPoint
+import illyan.jay.BuildConfig
 import illyan.jay.data.network.model.FirestorePath
 import illyan.jay.data.network.model.FirestoreSession
 import illyan.jay.data.network.model.FirestoreUserPreferences
+import illyan.jay.data.network.serializers.TimestampSerializer
 import illyan.jay.domain.model.DomainLocation
 import illyan.jay.domain.model.DomainPreferences
 import illyan.jay.domain.model.DomainSession
 import illyan.jay.util.toGeoPoint
 import illyan.jay.util.toTimestamp
 import illyan.jay.util.toZonedDateTime
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.protobuf.ProtoBuf
+import timber.log.Timber
+import java.io.ByteArrayOutputStream
 import java.util.UUID
+import java.util.zip.Deflater
+import java.util.zip.DeflaterOutputStream
+import java.util.zip.GZIPOutputStream
 import kotlin.time.Duration.Companion.minutes
 
 fun DomainSession.toFirestoreModel() = FirestoreSession(
@@ -78,6 +94,7 @@ fun DomainPreferences.toFirestoreModel() = FirestoreUserPreferences(
     lastUpdate = lastUpdate.toTimestamp(),
 )
 
+@OptIn(ExperimentalSerializationApi::class)
 fun List<DomainLocation>.toPath(
     sessionUUID: String,
     ownerUUID: String
@@ -132,7 +149,7 @@ fun List<DomainLocation>.toPath(
         }
     }
 
-    return FirestorePath(
+    val path = FirestorePath(
         uuid = UUID.randomUUID().toString(),
         sessionUUID = sessionUUID,
         ownerUUID = ownerUUID,
@@ -150,7 +167,156 @@ fun List<DomainLocation>.toPath(
         verticalAccuracyChangeTimestamps = verticalAccuracyChangeTimestamps,
         verticalAccuracyChanges = verticalAccuracyChanges.map { it.toInt() },
     )
+
+    if (BuildConfig.DEBUG) {
+        // Size comparison between raw location data path and compressed data structures.
+
+        // Conclusion: Path reduces data size ~13% compared to raw location data with SessionUUID
+        // and optimized sensory data (Short, Byte used instead of Int).
+        // Raw, optimized location data without SessionUUID, is taking up ~49% less space
+        // compared to raw location data with SessionUUID (repeated).
+
+        // Size ratio:
+        // - List<DomainLocations> = 1.00
+        // - FirestorePath = 0.87
+        // - List<LocationWithoutSessionIdOptimized> = 0.51
+        // - List<LocationWithoutSessionId> = 0.51
+        // - Base64 GZIP compressed List<LocationWithoutSessionIdOptimized> =
+        // - Base64 ZLIB compressed List<LocationWithoutSessionIdOptimized> =
+
+        val locationsParcel = Parcel.obtain()
+        forEach { it.writeToParcel(locationsParcel, Parcelable.PARCELABLE_WRITE_RETURN_VALUE) }
+        val locationsDataSizeInBytes = locationsParcel.dataSize()
+        Timber.i("Locations (with sessionUUID) for session $sessionUUID size is around $locationsDataSizeInBytes bytes")
+        locationsParcel.recycle()
+
+        val pathParcel = Parcel.obtain()
+        path.writeToParcel(pathParcel, Parcelable.PARCELABLE_WRITE_RETURN_VALUE)
+        val pathDataSizeInBytes = pathParcel.dataSize()
+        Timber.i("Path for session $sessionUUID size is around $pathDataSizeInBytes bytes")
+        pathParcel.recycle()
+
+        val rawOptimizedLocationsParcel = Parcel.obtain()
+        val rawOptimizedLocations = map {
+            LocationWithoutSessionIdOptimized(
+                zonedDateTime = it.zonedDateTime.toTimestamp(),
+                latitude = it.latitude,
+                longitude = it.longitude,
+                speed = it.speed,
+                accuracy = it.accuracy,
+                bearing = it.bearing,
+                bearingAccuracy = it.bearingAccuracy,
+                altitude = it.altitude,
+                speedAccuracy = it.speedAccuracy,
+                verticalAccuracy = it.verticalAccuracy
+            )
+        }
+        rawOptimizedLocations.forEach { it.writeToParcel(rawOptimizedLocationsParcel, Parcelable.PARCELABLE_WRITE_RETURN_VALUE) }
+        val rawOptimizedLocationsDataSizeInBytes = rawOptimizedLocationsParcel.dataSize()
+        Timber.i("Locations (without sessionUUID, optimized) for session $sessionUUID size is around $rawOptimizedLocationsDataSizeInBytes bytes")
+        rawOptimizedLocationsParcel.recycle()
+
+        val rawLocationsParcel = Parcel.obtain()
+        val rawLocations = map {
+            LocationWithoutSessionId(
+                zonedDateTime = it.zonedDateTime.toTimestamp(),
+                latitude = it.latitude,
+                longitude = it.longitude,
+                speed = it.speed,
+                accuracy = it.accuracy.toInt(),
+                bearing = it.bearing.toInt(),
+                bearingAccuracy = it.bearingAccuracy.toInt(),
+                altitude = it.altitude.toInt(),
+                speedAccuracy = it.speedAccuracy,
+                verticalAccuracy = it.verticalAccuracy.toInt()
+            )
+        }
+        rawLocations.forEach { it.writeToParcel(rawLocationsParcel, Parcelable.PARCELABLE_WRITE_RETURN_VALUE) }
+        val rawLocationsDataSizeInBytes = rawLocationsParcel.dataSize()
+        Timber.i("Locations (without sessionUUID, unoptimized) for session $sessionUUID size is around $rawLocationsDataSizeInBytes bytes")
+        rawLocationsParcel.recycle()
+
+        val gzipByteArrayOutputStream = ByteArrayOutputStream()
+        val gzipOutputStream = GZIPOutputStream(gzipByteArrayOutputStream)
+        gzipOutputStream.write(ProtoBuf.encodeToByteArray(rawOptimizedLocations))
+        val gzipCompressedBytes = gzipByteArrayOutputStream.toByteArray()
+        val gzipBase64String = Base64.encodeToString(gzipCompressedBytes, Base64.DEFAULT)
+        val gzipBase64Parcel = Parcel.obtain()
+        gzipBase64Parcel.writeString(gzipBase64String)
+        val gzipBase64DataSizeInBytes = gzipBase64Parcel.dataSize()
+        Timber.i("Compressed (GZIP) locations (without sessionUUID, optimized) for session $sessionUUID size is around $gzipBase64DataSizeInBytes bytes")
+        gzipBase64Parcel.recycle()
+
+        val zlibByteArrayOutputStream = ByteArrayOutputStream()
+        val deflater = Deflater(Deflater.BEST_COMPRESSION)
+        val deflaterOutputStream = DeflaterOutputStream(zlibByteArrayOutputStream, deflater)
+        deflaterOutputStream.write(ProtoBuf.encodeToByteArray(rawOptimizedLocations))
+        val zlibCompressedBytes = zlibByteArrayOutputStream.toByteArray()
+        val zlibBase64String = Base64.encodeToString(zlibCompressedBytes, Base64.DEFAULT)
+        val zlibBase64Parcel = Parcel.obtain()
+        zlibBase64Parcel.writeString(zlibBase64String)
+        val zlibBase64DataSizeInBytes = zlibBase64Parcel.dataSize()
+        Timber.i("Compressed (ZLIB) locations (without sessionUUID, optimized) for session $sessionUUID size is around $zlibBase64DataSizeInBytes bytes")
+        zlibBase64Parcel.recycle()
+
+        val zstdCompressedBytes = Zstd.compress(ProtoBuf.encodeToByteArray(rawOptimizedLocations), Zstd.maxCompressionLevel())
+        val zstdBase64String = Base64.encodeToString(zstdCompressedBytes, Base64.DEFAULT)
+        val zstdBase64Parcel = Parcel.obtain()
+        zstdBase64Parcel.writeString(zstdBase64String)
+        val zstdBase64DataSizeInBytes = zstdBase64Parcel.dataSize()
+        Timber.i("Compressed (Zstd) locations (without sessionUUID, optimized) for session $sessionUUID size is around $zstdBase64DataSizeInBytes bytes")
+        zstdBase64Parcel.recycle()
+
+//        Brotli4jLoader.ensureAvailability()
+//        if (Brotli4jLoader.isAvailable()) {
+//            val brotliByteArrayOutputStream = ByteArrayOutputStream()
+//            val encoderParams = Encoder.Parameters().setQuality(8)
+//            val brotliOutputStream = BrotliOutputStream(brotliByteArrayOutputStream, encoderParams)
+//            brotliOutputStream.write(ProtoBuf.encodeToByteArray(rawOptimizedLocations))
+//            val brotliCompressedBytes = brotliByteArrayOutputStream.toByteArray()
+//            val brotliBase64String = Base64.encodeToString(brotliCompressedBytes, Base64.DEFAULT)
+//            val brotliBase64Parcel = Parcel.obtain()
+//            brotliBase64Parcel.writeString(brotliBase64String)
+//            val brotliBase64DataSizeInBytes = brotliBase64Parcel.dataSize()
+//            Timber.i("Compressed (Brotli) locations (without sessionUUID, optimized) for session $sessionUUID size is around $brotliBase64DataSizeInBytes bytes")
+//            brotliBase64Parcel.recycle()
+//        }
+    }
+
+    return path
 }
+
+@Serializable
+@Parcelize
+data class LocationWithoutSessionIdOptimized(
+    @Serializable(with = TimestampSerializer::class)
+    val zonedDateTime: Timestamp,
+    val latitude: Float,
+    val longitude: Float,
+    var speed: Float = Float.MIN_VALUE,
+    var accuracy: Byte = Byte.MIN_VALUE,
+    var bearing: Short = Short.MIN_VALUE,
+    var bearingAccuracy: Short = Short.MIN_VALUE, // in degrees
+    var altitude: Short = Short.MIN_VALUE,
+    var speedAccuracy: Float = Float.MIN_VALUE, // in meters per second
+    var verticalAccuracy: Short = Short.MIN_VALUE, // in meters
+) : Parcelable
+
+@Serializable
+@Parcelize
+data class LocationWithoutSessionId(
+    @Serializable(with = TimestampSerializer::class)
+    val zonedDateTime: Timestamp,
+    val latitude: Float,
+    val longitude: Float,
+    var speed: Float = Float.MIN_VALUE,
+    var accuracy: Int = Int.MIN_VALUE,
+    var bearing: Int = Int.MIN_VALUE,
+    var bearingAccuracy: Int = Int.MIN_VALUE, // in degrees
+    var altitude: Int = Int.MIN_VALUE,
+    var speedAccuracy: Float = Float.MIN_VALUE, // in meters per second
+    var verticalAccuracy: Int = Int.MIN_VALUE, // in meters
+) : Parcelable
 
 fun List<DomainLocation>.toPaths(
     sessionUUID: String,

--- a/app/src/main/java/illyan/jay/data/network/datasource/LocationNetworkDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/network/datasource/LocationNetworkDataSource.kt
@@ -18,8 +18,6 @@
 
 package illyan.jay.data.network.datasource
 
-import android.os.Parcel
-import android.os.Parcelable
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.WriteBatch
 import com.google.maps.android.ktx.utils.sphericalPathLength
@@ -51,7 +49,7 @@ class LocationNetworkDataSource @Inject constructor(
         if (authInteractor.isUserSignedIn) {
             firestore
                 .collection(FirestorePath.CollectionName)
-                .whereEqualTo("sessionUUID", sessionUUID)
+                .whereEqualTo(FirestorePath.FieldSessionUUID, sessionUUID)
                 .addSnapshotListener { snapshot, error ->
                     if (error != null) {
                         Timber.e(error, "Error while getting path for session $sessionUUID: ${error.message}")
@@ -148,18 +146,7 @@ class LocationNetworkDataSource @Inject constructor(
                 .document(it.uuid) to it
         }
         pathRefs.forEach {
-            val parcel = Parcel.obtain()
-            it.second.writeToParcel(parcel, Parcelable.PARCELABLE_WRITE_RETURN_VALUE)
-            val dataSizeInBytes = parcel.dataSize()
-            Timber.i("Path ${it.second.uuid.take(4)} for session ${it.second.sessionUUID.take(4)} size is around $dataSizeInBytes bytes")
-            // TODO: make size calculations more reliable and easier to implement
-            val maxSizeInBytes = 1_048_576
-            if (dataSizeInBytes < maxSizeInBytes) {
-                batch.set(it.first, it.second)
-            } else {
-                Timber.d("Not uploading this path, as $dataSizeInBytes bytes exceeds the $maxSizeInBytes byte limit")
-            }
-            parcel.recycle()
+            batch.set(it.first, it.second)
         }
     }
 

--- a/app/src/main/java/illyan/jay/data/network/model/FirestoreLocation.kt
+++ b/app/src/main/java/illyan/jay/data/network/model/FirestoreLocation.kt
@@ -1,0 +1,23 @@
+package illyan.jay.data.network.model
+
+import android.os.Parcelable
+import com.google.firebase.Timestamp
+import illyan.jay.data.network.serializers.TimestampSerializer
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Parcelize
+data class FirestoreLocation(
+    @Serializable(with = TimestampSerializer::class)
+    val timestamp: Timestamp,
+    val latitude: Float,
+    val longitude: Float,
+    var speed: Float = Float.MIN_VALUE,
+    var accuracy: Int = Int.MIN_VALUE,
+    var bearing: Int = Int.MIN_VALUE,
+    var bearingAccuracy: Int = Int.MIN_VALUE, // in degrees
+    var altitude: Int = Int.MIN_VALUE,
+    var speedAccuracy: Float = Float.MIN_VALUE, // in meters per second
+    var verticalAccuracy: Int = Int.MIN_VALUE, // in meters
+) : Parcelable

--- a/app/src/main/java/illyan/jay/data/network/model/FirestorePath.kt
+++ b/app/src/main/java/illyan/jay/data/network/model/FirestorePath.kt
@@ -18,53 +18,22 @@
 
 package illyan.jay.data.network.model
 
-import android.os.Parcelable
-import com.google.firebase.Timestamp
+import com.google.firebase.firestore.Blob
 import com.google.firebase.firestore.DocumentId
-import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.firestore.PropertyName
-import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.TypeParceler
 
-// TODO: test data sizes with simple conversion (only one timestamp per location data (coord, bearing, altitide, ...))
-@Parcelize
-@TypeParceler<GeoPoint, GeoPointParceler>
 data class FirestorePath(
     @DocumentId
     val uuid: String = "",
     @PropertyName(FieldSessionUUID) val sessionUUID: String = "", // reference of the session this path is part of
     @PropertyName(FieldOwnerUUID) val ownerUUID: String = "",
-    @PropertyName(FieldAccuracyChangeTimestamps) val accuracyChangeTimestamps: List<Timestamp> = emptyList(),
-    @PropertyName(FieldAccuracyChanges) val accuracyChanges: List<Int> = emptyList(),
-    @PropertyName(FieldAltitudes) val altitudes: List<Int> = emptyList(),
-    @PropertyName(FieldBearingAccuracyChangeTimestamps) val bearingAccuracyChangeTimestamps: List<Timestamp> = emptyList(),
-    @PropertyName(FieldBearingAccuracyChanges) val bearingAccuracyChanges: List<Int> = emptyList(),
-    @PropertyName(FieldBearings) val bearings: List<Int> = emptyList(),
-    @PropertyName(FieldCoords) val coords: List<GeoPoint> = emptyList(),
-    @PropertyName(FieldSpeeds) val speeds: List<Float> = emptyList(),
-    @PropertyName(FieldSpeedAccuracyChangeTimestamps) val speedAccuracyChangeTimestamps: List<Timestamp> = emptyList(),
-    @PropertyName(FieldSpeedAccuracyChanges) val speedAccuracyChanges: List<Float> = emptyList(),
-    @PropertyName(FieldTimestamps) val timestamps: List<Timestamp> = emptyList(),
-    @PropertyName(FieldVerticalAccuracyChangeTimestamps) val verticalAccuracyChangeTimestamps: List<Timestamp> = emptyList(),
-    @PropertyName(FieldVerticalAccuracyChanges) val verticalAccuracyChanges: List<Int> = emptyList()
-) : Parcelable {
+    @PropertyName(FieldLocations) val locations: Blob = Blob.fromBytes(ByteArray(0))
+) {
     companion object {
         const val CollectionName = "paths"
         const val FieldSessionUUID = "sessionUUID"
         const val FieldOwnerUUID = "ownerUUID"
-        const val FieldAccuracyChangeTimestamps = "accuracyChangeTimestamps"
-        const val FieldAccuracyChanges = "accuracyChanges"
-        const val FieldAltitudes = "altitudes"
-        const val FieldBearingAccuracyChangeTimestamps = "bearingAccuracyChangeTimestamps"
-        const val FieldBearingAccuracyChanges = "bearingAccuracyChanges"
-        const val FieldBearings = "bearings"
-        const val FieldCoords = "coords"
-        const val FieldSpeeds = "speeds"
-        const val FieldSpeedAccuracyChangeTimestamps = "speedAccuracyChangeTimestamps"
-        const val FieldSpeedAccuracyChanges = "speedAccuracyChanges"
-        const val FieldTimestamps = "timestamps"
-        const val FieldVerticalAccuracyChangeTimestamps = "verticalAccuracyChangeTimestamps"
-        const val FieldVerticalAccuracyChanges = "verticalAccuracyChanges"
+        const val FieldLocations = "locations"
     }
 }
 

--- a/app/src/main/java/illyan/jay/data/network/serializers/TimestampSerializer.kt
+++ b/app/src/main/java/illyan/jay/data/network/serializers/TimestampSerializer.kt
@@ -16,25 +16,29 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package illyan.jay.data.disk.serializers
+package illyan.jay.data.network.serializers
 
+import com.google.firebase.Timestamp
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import java.time.ZonedDateTime
 
-object ZonedDateTimeSerializer : KSerializer<ZonedDateTime> {
+object TimestampSerializer : KSerializer<Timestamp> {
     override val descriptor: SerialDescriptor
-        get() = PrimitiveSerialDescriptor("java.time.ZonedDateTime", PrimitiveKind.STRING)
+        get() = buildClassSerialDescriptor("com.google.firebase.Timestamp") {
+            element<Long>("seconds")
+            element<Int>("nanoseconds")
+        }
 
-    override fun deserialize(decoder: Decoder): ZonedDateTime {
-        return ZonedDateTime.parse(decoder.decodeString())
+    override fun deserialize(decoder: Decoder): Timestamp {
+        return Timestamp(decoder.decodeLong(), decoder.decodeInt())
     }
 
-    override fun serialize(encoder: Encoder, value: ZonedDateTime) {
-        encoder.encodeString(value.toString())
+    override fun serialize(encoder: Encoder, value: Timestamp) {
+        encoder.encodeLong(value.seconds)
+        encoder.encodeInt(value.nanoseconds)
     }
 }

--- a/app/src/main/java/illyan/jay/domain/model/DomainLocation.kt
+++ b/app/src/main/java/illyan/jay/domain/model/DomainLocation.kt
@@ -18,7 +18,10 @@
 
 package illyan.jay.domain.model
 
+import android.os.Parcelable
 import com.google.android.gms.maps.model.LatLng
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import java.time.ZonedDateTime
 
 /**
@@ -38,6 +41,7 @@ import java.time.ZonedDateTime
  * @property verticalAccuracy
  * @constructor Create empty Domain location
  */
+@Parcelize
 data class DomainLocation(
     var sessionUUID: String,
     val zonedDateTime: ZonedDateTime,
@@ -50,6 +54,6 @@ data class DomainLocation(
     var altitude: Short = Short.MIN_VALUE,
     var speedAccuracy: Float = Float.MIN_VALUE, // in meters per second
     var verticalAccuracy: Short = Short.MIN_VALUE, // in meters
-) {
-    val latLng = LatLng(latitude.toDouble(), longitude.toDouble())
+) : Parcelable {
+    @IgnoredOnParcel val latLng = LatLng(latitude.toDouble(), longitude.toDouble())
 }

--- a/app/src/main/java/illyan/jay/ui/components/Tooltip.kt
+++ b/app/src/main/java/illyan/jay/ui/components/Tooltip.kt
@@ -66,14 +66,12 @@ fun TooltipElevatedCard(
 ) {
     val tooltipState = remember { PlainTooltipState() }
     val coroutineScope = rememberCoroutineScope()
+
     LaunchedEffect(tooltipState.isVisible) {
         if (tooltipState.isVisible) onShowTooltip() else onDismissTooltip()
     }
-
     var currentTooltip by remember {
-        mutableStateOf<@Composable () -> Unit>(
-            if (enabled || disabledTooltip == null) tooltip else disabledTooltip
-        )
+        mutableStateOf(if (enabled || disabledTooltip == null) tooltip else disabledTooltip)
     }
     LaunchedEffect(enabled, tooltipState.isVisible) {
         if (!tooltipState.isVisible) {
@@ -82,7 +80,6 @@ fun TooltipElevatedCard(
             currentTooltip = if (enabled || disabledTooltip == null) tooltip else disabledTooltip
         }
     }
-
     PlainTooltipBox(
         modifier = modifier,
         containerColor = MaterialTheme.colorScheme.surfaceVariant,

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.15'
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.44.2'
         classpath 'de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0'
-        classpath 'org.jetbrains.kotlin:kotlin-serialization:1.8.0'
+        classpath 'org.jetbrains.kotlin:kotlin-serialization:1.8.10'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'
         classpath 'com.google.firebase:perf-plugin:1.4.2'
     }


### PR DESCRIPTION
Experimented with reducing size of `Paths`. Compressed bytes via the Zstandard algorithm, and with a more optimized data structure, enabled a ~90% reduction in size. Other small refactors and fixes.