### PR TITLE
Fixes to crashing due to `Firestore` batch being already commited

### DIFF
--- a/app/src/main/java/illyan/jay/data/network/datasource/UserNetworkDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/network/datasource/UserNetworkDataSource.kt
@@ -198,9 +198,13 @@ class UserNetworkDataSource @Inject constructor(
         }
     }
 
-    fun deleteUserData(batch: WriteBatch) {
+    fun deleteUserData(
+        batch: WriteBatch,
+        onWriteFinished: () -> Unit = {}
+    ) {
         _userReference.value?.apply {
             batch.delete(reference)
+            onWriteFinished()
         }
     }
 }


### PR DESCRIPTION
When using `Coroutines`, batches could be commited before a write could have happened. This threw an exception. Now waiting for each write to finish before commiting a batch. Solution could be improved, but it is robust enough, not to cause a headache in the long term.