### PR TITLE
80 wait all writes when writing to batch

### DIFF
--- a/app/src/main/java/illyan/jay/data/network/datasource/SessionNetworkDataSource.kt
+++ b/app/src/main/java/illyan/jay/data/network/datasource/SessionNetworkDataSource.kt
@@ -155,7 +155,7 @@ class SessionNetworkDataSource @Inject constructor(
         val userRef = firestore
             .collection(FirestoreUser.CollectionName)
             .document(userUUID)
-        Timber.i("Deleting ${domainSessions.size} sessions for user ${userUUID.take(4)} from the cloud")
+        Timber.i("Batch remove ${domainSessions.size} sessions for user ${userUUID.take(4)} from the cloud")
         batch.set(
             userRef,
             mapOf(FirestoreUser.FieldSessions to FieldValue.arrayRemove(*domainSessions.map { it.toFirestoreModel() }.toTypedArray())),

--- a/app/src/main/java/illyan/jay/domain/interactor/SessionInteractor.kt
+++ b/app/src/main/java/illyan/jay/domain/interactor/SessionInteractor.kt
@@ -30,6 +30,7 @@ import illyan.jay.data.network.datasource.UserNetworkDataSource
 import illyan.jay.di.CoroutineScopeIO
 import illyan.jay.domain.model.DomainLocation
 import illyan.jay.domain.model.DomainSession
+import illyan.jay.util.awaitAllThenCommit
 import illyan.jay.util.completeNext
 import illyan.jay.util.sphericalPathLength
 import kotlinx.coroutines.CompletableDeferred
@@ -169,10 +170,7 @@ class SessionInteractor @Inject constructor(
             batch = batch,
             onWriteFinished = { completableDeferred.completeNext() }
         )
-        Timber.v("Awaiting modifications to batch")
-        awaitAll(*completableDeferred.toTypedArray())
-        Timber.d("Committing batch")
-        batch.commit()
+        batch.awaitAllThenCommit(completableDeferred)
     }
 
     suspend fun deleteAllSyncedData() {
@@ -188,10 +186,7 @@ class SessionInteractor @Inject constructor(
             batch = batch,
             onWriteFinished = { completableDeferred.completeNext() }
         )
-        Timber.v("Awaiting modifications to batch")
-        awaitAll(*completableDeferred.toTypedArray())
-        Timber.d("Committing batch")
-        batch.commit()
+        batch.awaitAllThenCommit(completableDeferred)
     }
 
     fun uploadSessions(
@@ -547,10 +542,7 @@ class SessionInteractor @Inject constructor(
             sessionUUIDs = sessionUUIDs,
             onWriteFinished = { completableDeferred.completeNext() }
         )
-        Timber.v("Awaiting modifications to batch")
-        awaitAll(*completableDeferred.toTypedArray())
-        Timber.d("Committing batch")
-        batch.commit()
+        batch.awaitAllThenCommit(completableDeferred)
     }
 
     suspend fun deleteSessionFromCloud(domainSession: DomainSession) = deleteSessionsFromCloud(listOf(domainSession))

--- a/app/src/main/java/illyan/jay/util/Util.kt
+++ b/app/src/main/java/illyan/jay/util/Util.kt
@@ -211,7 +211,7 @@ fun Modifier.cardPlaceholder(
 }
 
 /**
- * Finds all potential URLs's start and end indices in the String.
+ * Finds all potential URLs' start and end indices in the String.
  */
 fun String.findUrlIntervals(
     urlRegex: Regex = "[(http(s)?):\\/\\/(www\\.)?a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)".toRegex()

--- a/app/src/main/java/illyan/jay/util/Util.kt
+++ b/app/src/main/java/illyan/jay/util/Util.kt
@@ -48,6 +48,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import illyan.jay.domain.model.DomainLocation
+import kotlinx.coroutines.CompletableDeferred
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
@@ -229,3 +230,5 @@ fun Color.setLightness(lightness: Float): Color {
     hsl[2] = lightness
     return Color.hsl(hsl[0], hsl[1], hsl[2], alpha = alpha)
 }
+
+fun List<CompletableDeferred<Unit>>.completeNext() = firstOrNull { !it.isCompleted }?.complete(Unit) ?: false

--- a/app/src/main/java/illyan/jay/util/Util.kt
+++ b/app/src/main/java/illyan/jay/util/Util.kt
@@ -42,6 +42,7 @@ import com.google.accompanist.placeholder.material.shimmer
 import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.GeoPoint
+import com.google.firebase.firestore.WriteBatch
 import com.google.maps.android.SphericalUtil
 import com.google.maps.android.ktx.utils.sphericalPathLength
 import com.mapbox.geojson.Point
@@ -49,6 +50,9 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import illyan.jay.domain.model.DomainLocation
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.awaitAll
+import timber.log.Timber
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
@@ -232,3 +236,12 @@ fun Color.setLightness(lightness: Float): Color {
 }
 
 fun List<CompletableDeferred<Unit>>.completeNext() = firstOrNull { !it.isCompleted }?.complete(Unit) ?: false
+
+suspend inline fun <reified T> WriteBatch.awaitAllThenCommit(vararg deferred: Deferred<T>) {
+    Timber.v("Awaiting modifications to batch")
+    awaitAll(*deferred)
+    Timber.d("Committing batch")
+    commit()
+}
+
+suspend inline fun <reified T> WriteBatch.awaitAllThenCommit(deferred: List<Deferred<T>>) = awaitAllThenCommit(*deferred.toTypedArray())


### PR DESCRIPTION
Extended `Firestore` functionality to have a `runBatch` function with number of writes, that must be completed in order to commit a batch.